### PR TITLE
feat(database): enhance song management with existence checks

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/DatabaseDao.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
+import timber.log.Timber
 import java.text.Collator
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -572,6 +573,9 @@ interface DatabaseDao {
     @Query("SELECT * FROM song WHERE id = :songId LIMIT 1")
     fun getSongByIdBlocking(songId: String): Song?
 
+    @Query("SELECT EXISTS(SELECT 1 FROM song WHERE id = :songId)")
+    fun songExistsBlocking(songId: String): Boolean
+
     @Transaction
     @Query("SELECT * FROM song WHERE id IN (:songIds)")
     suspend fun getSongsByIds(songIds: List<String>): List<Song>
@@ -1005,12 +1009,16 @@ interface DatabaseDao {
     fun addSongToPlaylist(playlist: Playlist, songIds: List<String>) {
         var position = playlist.songCount
         songIds.forEach { id ->
+            if (!songExistsBlocking(id)) {
+                Timber.w("addSongToPlaylist: skipping songId=$id — not found in database")
+                return@forEach
+            }
             insert(
                 PlaylistSongMap(
                     songId = id,
                     playlistId = playlist.id,
-                    position = position++
-                )
+                    position = position++,
+                ),
             )
         }
     }
@@ -1373,7 +1381,8 @@ interface DatabaseDao {
                 if (existingSong != null) {
                     update(existingSong, it)
                 }
-            }.mapIndexed { index, song ->
+            }.filter { songExistsBlocking(it.id) }
+            .mapIndexed { index, song ->
                 SongAlbumMap(
                     songId = song.id,
                     albumId = albumPage.album.browseId,
@@ -1388,6 +1397,7 @@ interface DatabaseDao {
                     name = artist.name,
                 )
             }?.onEach(::insert)
+            ?.filter { getArtistById(it.id) != null }
             ?.mapIndexed { index, artist ->
                 AlbumArtistMap(
                     albumId = albumPage.album.browseId,
@@ -1492,7 +1502,8 @@ interface DatabaseDao {
                 if (existingSong != null) {
                     update(existingSong, it)
                 }
-            }.mapIndexed { index, song ->
+            }.filter { songExistsBlocking(it.id) }
+            .mapIndexed { index, song ->
                 SongAlbumMap(
                     songId = song.id,
                     albumId = albumPage.album.browseId,
@@ -1501,7 +1512,6 @@ interface DatabaseDao {
             }.forEach(::upsert)
 
         albumPage.album.artists?.let { artists ->
-            // Recreate album artists
             albumArtistMaps(album.id).forEach(::delete)
             artists
                 .map { artist ->
@@ -1511,6 +1521,7 @@ interface DatabaseDao {
                         name = artist.name,
                     )
                 }.onEach(::insert)
+                .filter { getArtistById(it.id) != null }
                 .mapIndexed { index, artist ->
                     AlbumArtistMap(
                         albumId = albumPage.album.browseId,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1242,10 +1242,11 @@ class MusicService :
                 relatedPage.songs
                     .map(SongItem::toMediaMetadata)
                     .onEach(::insert)
+                    .filter { songExistsBlocking(it.id) }
                     .map {
                         RelatedSongMap(
                             songId = mediaId,
-                            relatedSongId = it.id
+                            relatedSongId = it.id,
                         )
                     }
                     .forEach(::insert)


### PR DESCRIPTION
- Added `songExistsBlocking` method to `DatabaseDao` for checking song existence.
- Updated `addSongToPlaylist` to skip songs not found in the database, logging a warning.
- Refactored song retrieval in `SyncUtils` to use `getSongByIdBlocking` for better clarity.
- Filtered songs in `MusicService` before processing to ensure only existing songs are handled.