### PR TITLE
fix(spotify): implement centralized Spotify token management and enhance playback error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ Yes. Meld streams audio through YouTube Music's infrastructure like any other mu
 
 No. Meld uses Spotify for data only (your library, top tracks, search results) — not for audio streaming. Audio is streamed through YouTube Music. A free Spotify account works perfectly.
 
+### Q: Some songs won't play — I get a playback error
+
+Certain tracks on YouTube may be age-restricted or region-locked. If you're not logged into YouTube, some of these tracks cannot be played because YouTube requires authentication to verify your identity. To fix this:
+
+1. Go to **Settings → Account** and log in with your YouTube / Google account
+2. Go back and try playing the song again
+
+If the track still doesn't play after logging in, it may be restricted in your country or permanently unavailable.
+
 ### Q: Why do some songs not match correctly?
 
 The Spotify-to-YouTube matching uses fuzzy matching on title, artist name, and duration. In rare cases (live versions, remasters, regional variants), the match may not be perfect. Matched results are cached locally so they're resolved instantly on subsequent plays.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,8 +23,8 @@ android {
         applicationId = "com.meld.app"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3
-        versionName = "0.2.0"
+        versionCode = 4
+        versionName = "0.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/PlaybackError.kt
@@ -35,28 +35,28 @@ import com.metrolist.music.R
 @Composable
 fun PlaybackError(
     error: PlaybackException,
+    isLoggedIn: Boolean,
     retry: () -> Unit,
 ) {
-    // Build detailed error info for debugging
     val rawErrorMessage = error.cause?.cause?.message 
         ?: error.cause?.message 
         ?: error.message 
         ?: stringResource(R.string.error_unknown)
     
-    // Check if this is an age-restricted content error
-    // Age-restricted content typically returns 403 Forbidden or contains age-related messages
-    val isAgeRestricted = rawErrorMessage.contains("age", ignoreCase = true) ||
+    val isRestricted = rawErrorMessage.contains("age", ignoreCase = true) ||
             rawErrorMessage.contains("Sign in to confirm your age", ignoreCase = true) ||
             rawErrorMessage.contains("LOGIN_REQUIRED", ignoreCase = true) ||
             rawErrorMessage.contains("confirm your age", ignoreCase = true) ||
-            rawErrorMessage.contains("403", ignoreCase = true) ||
-            rawErrorMessage.contains("Response code: 403", ignoreCase = true) ||
-            error.errorCode == PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS
+            rawErrorMessage.contains("AGE_CHECK_REQUIRED", ignoreCase = true) ||
+            rawErrorMessage.contains("AGE_VERIFICATION_REQUIRED", ignoreCase = true) ||
+            rawErrorMessage.contains("CONTENT_CHECK_REQUIRED", ignoreCase = true) ||
+            rawErrorMessage.contains("country", ignoreCase = true) ||
+            error.errorCode == PlaybackException.ERROR_CODE_REMOTE_ERROR
     
-    val errorMessage = if (isAgeRestricted) {
-        "This app does not support playing age-restricted songs. We are working on fixing this issue."
-    } else {
-        rawErrorMessage
+    val errorMessage = when {
+        isRestricted && !isLoggedIn -> stringResource(R.string.error_restricted_not_logged_in)
+        isRestricted && isLoggedIn -> stringResource(R.string.error_restricted_logged_in)
+        else -> rawErrorMessage
     }
     
     Column(

--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
@@ -74,6 +74,7 @@ import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
 import com.metrolist.music.constants.CropAlbumArtKey
 import com.metrolist.music.constants.HidePlayerThumbnailKey
+import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.constants.PlayerBackgroundStyle
 import com.metrolist.music.constants.PlayerBackgroundStyleKey
 import com.metrolist.music.constants.PlayerHorizontalPadding
@@ -84,6 +85,7 @@ import com.metrolist.music.listentogether.RoomRole
 import com.metrolist.music.ui.component.CastButton
 import com.metrolist.music.utils.rememberEnumPreference
 import com.metrolist.music.utils.rememberPreference
+import com.metrolist.innertube.utils.parseCookieString
 import kotlinx.coroutines.delay
 
 /**
@@ -213,6 +215,12 @@ fun Thumbnail(
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsState()
 
+    // YouTube login status
+    val innerTubeCookie by rememberPreference(InnerTubeCookieKey, "")
+    val isYouTubeLoggedIn = remember(innerTubeCookie) {
+        "SAPISID" in parseCookieString(innerTubeCookie)
+    }
+
     // Preferences - computed once
     // Disable swipe for Listen Together guests
     val swipeThumbnailPref by rememberPreference(SwipeThumbnailKey, true)
@@ -313,6 +321,7 @@ fun Thumbnail(
             error?.let { playbackError ->
                 PlaybackError(
                     error = playbackError,
+                    isLoggedIn = isYouTubeLoggedIn,
                     retry = playerConnection.player::prepare,
                 )
             }

--- a/app/src/main/kotlin/com/metrolist/music/utils/SpotifyTokenManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/SpotifyTokenManager.kt
@@ -1,0 +1,116 @@
+package com.metrolist.music.utils
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import com.metrolist.music.constants.SpotifyAccessTokenKey
+import com.metrolist.music.constants.SpotifySpDcKey
+import com.metrolist.music.constants.SpotifySpKeyKey
+import com.metrolist.music.constants.SpotifyTokenExpiryKey
+import com.metrolist.spotify.Spotify
+import com.metrolist.spotify.SpotifyAuth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import timber.log.Timber
+
+/**
+ * Centralized Spotify token management. All token refresh operations go through
+ * this singleton to prevent race conditions from multiple callers refreshing
+ * simultaneously, which can cause redundant API calls and inconsistent state.
+ */
+object SpotifyTokenManager {
+    private lateinit var dataStore: DataStore<Preferences>
+    private val refreshMutex = Mutex()
+
+    private val _needsReLogin = MutableStateFlow(false)
+    val needsReLogin: StateFlow<Boolean> = _needsReLogin.asStateFlow()
+
+    fun init(dataStore: DataStore<Preferences>) {
+        this.dataStore = dataStore
+    }
+
+    /**
+     * Ensures a valid Spotify access token is available. If the current token
+     * is expired, acquires the shared mutex and refreshes it via sp_dc cookie.
+     * Only one refresh can happen at a time across the entire app.
+     *
+     * @return true if a valid token is set on [Spotify.accessToken], false otherwise
+     */
+    suspend fun ensureAuthenticated(): Boolean {
+        val settings = dataStore.data.first()
+        val accessToken = settings[SpotifyAccessTokenKey] ?: ""
+        val expiry = settings[SpotifyTokenExpiryKey] ?: 0L
+
+        if (accessToken.isEmpty()) {
+            Timber.d("SpotifyTokenManager: no token stored")
+            return false
+        }
+
+        if (System.currentTimeMillis() < expiry) {
+            Spotify.accessToken = accessToken
+            return true
+        }
+
+        return refreshMutex.withLock {
+            // Re-read after acquiring lock — another caller may have already refreshed
+            val freshSettings = dataStore.data.first()
+            val freshToken = freshSettings[SpotifyAccessTokenKey] ?: ""
+            val freshExpiry = freshSettings[SpotifyTokenExpiryKey] ?: 0L
+
+            if (freshToken.isNotEmpty() && System.currentTimeMillis() < freshExpiry) {
+                Spotify.accessToken = freshToken
+                Timber.d("SpotifyTokenManager: token already refreshed by another caller")
+                return@withLock true
+            }
+
+            val spDc = freshSettings[SpotifySpDcKey] ?: ""
+            val spKey = freshSettings[SpotifySpKeyKey] ?: ""
+            if (spDc.isEmpty()) {
+                Timber.w("SpotifyTokenManager: no sp_dc cookie available")
+                return@withLock false
+            }
+
+            Timber.d("SpotifyTokenManager: token expired, refreshing via cookie...")
+
+            SpotifyAuth.fetchAccessToken(spDc, spKey).fold(
+                onSuccess = { token ->
+                    Spotify.accessToken = token.accessToken
+                    dataStore.edit { prefs ->
+                        prefs[SpotifyAccessTokenKey] = token.accessToken
+                        prefs[SpotifyTokenExpiryKey] = token.accessTokenExpirationTimestampMs
+                    }
+                    _needsReLogin.value = false
+                    Timber.d("SpotifyTokenManager: token refreshed successfully")
+                    true
+                },
+                onFailure = { e ->
+                    Timber.e(e, "SpotifyTokenManager: refresh FAILED")
+
+                    val isCookieExpired = e.message?.contains("anonymous") == true ||
+                        e.message?.contains("expired") == true
+                    if (isCookieExpired) {
+                        Timber.w("SpotifyTokenManager: cookie expired, clearing session")
+                        dataStore.edit { prefs ->
+                            prefs.remove(SpotifyAccessTokenKey)
+                            prefs.remove(SpotifySpDcKey)
+                            prefs.remove(SpotifySpKeyKey)
+                            prefs.remove(SpotifyTokenExpiryKey)
+                        }
+                        Spotify.accessToken = null
+                        _needsReLogin.value = true
+                    }
+
+                    false
+                },
+            )
+        }
+    }
+
+    fun clearReLoginFlag() {
+        _needsReLogin.value = false
+    }
+}

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -496,6 +496,8 @@
     <string name="error_copied">Error info copied to clipboard</string>
     <string name="copy_error">Copy error</string>
     <string name="error_copy_hint">Copy error info to help developers debug the issue</string>
+    <string name="error_restricted_not_logged_in">Some tracks may not play due to age or country restrictions. Try logging into YouTube in Settings to resolve this issue.</string>
+    <string name="error_restricted_logged_in">This track is restricted (age or country) and cannot be played at this time.</string>
 
     <!-- Widget strings -->
     <string name="album_art">Album art</string>


### PR DESCRIPTION


- Introduced a new `SpotifyTokenManager` for centralized management of Spotify access tokens, improving token refresh handling and preventing race conditions.
- Updated the `App` class to utilize the new token manager for authentication.
- Enhanced playback error handling in the `PlaybackError` component to provide clearer messages based on user login status and content restrictions.
- Updated UI components to reflect changes in error handling and user authentication status.