### PR TITLE
merge - fix(spotify): enhance Spotify playlists loading and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,5 @@ app/src/main/cpp/coverart/
 
 # Internal development notes
 ROADMAP_NOTES.md
+.spotify_gql_endpoints.json
+SPOTIFY_GQL_REFERENCE.md

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/Items.kt
@@ -1273,6 +1273,8 @@ fun ItemThumbnail(
                     .build(),
                 contentDescription = null,
                 contentScale = if (cropAlbumArt) ContentScale.Crop else ContentScale.Fit,
+                placeholder = painterResource(R.drawable.music_note),
+                error = painterResource(R.drawable.music_note),
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(shape)

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/SpotifyLoginScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/SpotifyLoginScreen.kt
@@ -5,8 +5,8 @@
  * Spotify login using an embedded WebView.
  * Loads Spotify's web login page, which supports all auth methods
  * (email/password, Facebook, Google, Apple). After successful login,
- * the WebView redirect to open.spotify.com is intercepted BEFORE
- * the page loads, so the Spotify web player never starts.
+ * the WebView redirect to open.spotify.com is intercepted and the
+ * sp_dc cookie is extracted to fetch an access token.
  *
  * Token acquisition uses TOTP (Time-based One-Time Password) generated
  * from a community-maintained shared secret, following the approach used
@@ -33,15 +33,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -67,9 +70,13 @@ import com.metrolist.music.ui.utils.backToMain
 import com.metrolist.music.utils.dataStore
 import com.metrolist.spotify.Spotify
 import com.metrolist.spotify.SpotifyAuth
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
 
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("SetJavaScriptEnabled")
@@ -80,6 +87,9 @@ fun SpotifyLoginScreen(navController: NavController) {
     var isLoading by remember { mutableStateOf(true) }
     var isProcessing by remember { mutableStateOf(false) }
     var statusMessage by remember { mutableStateOf("") }
+    var hasError by remember { mutableStateOf(false) }
+    var retryCount by remember { mutableIntStateOf(0) }
+    val tokenFetchStarted = remember { AtomicBoolean(false) }
 
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
@@ -130,8 +140,10 @@ fun SpotifyLoginScreen(navController: NavController) {
                                 isLoading = false
                                 Timber.d("SpotifyLogin: page finished: $url")
 
-                                if (!isProcessing && url?.startsWith("https://open.spotify.com") == true) {
-                                    Timber.d("SpotifyLogin: fallback — extracting from onPageFinished")
+                                if (url?.startsWith("https://open.spotify.com") == true &&
+                                    tokenFetchStarted.compareAndSet(false, true)
+                                ) {
+                                    Timber.d("SpotifyLogin: extracting token from onPageFinished")
                                     extractAndFetchToken(
                                         view = view,
                                         context = context,
@@ -139,6 +151,8 @@ fun SpotifyLoginScreen(navController: NavController) {
                                         navController = navController,
                                         setProcessing = { isProcessing = it },
                                         setStatus = { statusMessage = it },
+                                        setError = { hasError = it },
+                                        tokenFetchStarted = tokenFetchStarted,
                                     )
                                 }
                             }
@@ -150,17 +164,26 @@ fun SpotifyLoginScreen(navController: NavController) {
                                 val requestUrl = request?.url?.toString() ?: return false
                                 Timber.d("SpotifyLogin: navigating to: $requestUrl")
 
-                                if (requestUrl.startsWith("https://open.spotify.com") && !isProcessing) {
-                                    Timber.d("SpotifyLogin: intercepting redirect to open.spotify.com")
-                                    extractAndFetchToken(
-                                        view = view,
-                                        context = context,
-                                        scope = scope,
-                                        navController = navController,
-                                        setProcessing = { isProcessing = it },
-                                        setStatus = { statusMessage = it },
-                                    )
-                                    return true
+                                if (requestUrl.startsWith("https://open.spotify.com")) {
+                                    val spDc = extractSpDcCookie()
+                                    if (spDc != null && tokenFetchStarted.compareAndSet(false, true)) {
+                                        Timber.d("SpotifyLogin: sp_dc available at redirect, processing immediately")
+                                        extractAndFetchToken(
+                                            view = view,
+                                            context = context,
+                                            scope = scope,
+                                            navController = navController,
+                                            setProcessing = { isProcessing = it },
+                                            setStatus = { statusMessage = it },
+                                            setError = { hasError = it },
+                                            tokenFetchStarted = tokenFetchStarted,
+                                        )
+                                        return true
+                                    }
+                                    // sp_dc not ready yet — let the page load so
+                                    // onPageFinished can pick up the cookie later
+                                    Timber.d("SpotifyLogin: sp_dc not ready at redirect, deferring to onPageFinished")
+                                    return false
                                 }
 
                                 return false
@@ -180,14 +203,36 @@ fun SpotifyLoginScreen(navController: NavController) {
                     contentAlignment = Alignment.Center,
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        CircularProgressIndicator()
-                        Spacer(modifier = Modifier.height(16.dp))
+                        if (!hasError) {
+                            CircularProgressIndicator()
+                            Spacer(modifier = Modifier.height(16.dp))
+                        }
                         Text(
                             text = statusMessage.ifEmpty {
                                 stringResource(R.string.spotify_logging_in)
                             },
                             style = MaterialTheme.typography.bodyLarge,
+                            color = if (hasError) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurface
+                            },
                         )
+                        if (hasError) {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            TextButton(
+                                onClick = {
+                                    hasError = false
+                                    isProcessing = false
+                                    statusMessage = ""
+                                    tokenFetchStarted.set(false)
+                                    retryCount++
+                                },
+                                modifier = Modifier.padding(horizontal = 16.dp),
+                            ) {
+                                Text(stringResource(R.string.retry))
+                            }
+                        }
                     }
                 }
             }
@@ -196,9 +241,28 @@ fun SpotifyLoginScreen(navController: NavController) {
 }
 
 /**
+ * Attempts to read the sp_dc cookie from the CookieManager.
+ * Returns null if the cookie is not yet available.
+ */
+private fun extractSpDcCookie(): String? {
+    val allCookies = CookieManager.getInstance().getCookie("https://open.spotify.com")
+    if (allCookies.isNullOrBlank()) return null
+
+    return allCookies.split(";")
+        .mapNotNull { cookie ->
+            val parts = cookie.trim().split("=", limit = 2)
+            if (parts.size == 2) parts[0].trim() to parts[1].trim() else null
+        }
+        .firstOrNull { it.first == "sp_dc" && it.second.isNotBlank() }
+        ?.second
+}
+
+/**
  * Extracts sp_dc/sp_key cookies, stops the WebView, and fetches the access
- * token in the background using [SpotifyAuth.fetchAccessToken] (which now
- * generates the required TOTP internally).
+ * token in the background using [SpotifyAuth.fetchAccessToken].
+ *
+ * Uses [tokenFetchStarted] as an atomic guard so only one invocation ever runs,
+ * preventing the race between shouldOverrideUrlLoading and onPageFinished.
  */
 private fun extractAndFetchToken(
     view: WebView?,
@@ -207,32 +271,38 @@ private fun extractAndFetchToken(
     navController: NavController,
     setProcessing: (Boolean) -> Unit,
     setStatus: (String) -> Unit,
+    setError: (Boolean) -> Unit,
+    tokenFetchStarted: AtomicBoolean,
 ) {
     val cookieManager = CookieManager.getInstance()
     val allCookies = cookieManager.getCookie("https://open.spotify.com")
-    Timber.d("SpotifyLogin: cookies for open.spotify.com: $allCookies")
+    Timber.d("SpotifyLogin: cookies present: ${!allCookies.isNullOrBlank()}")
 
-    if (allCookies.isNullOrBlank()) {
-        Timber.w("SpotifyLogin: no cookies found — cannot proceed")
-        return
-    }
-
-    val cookieMap = allCookies.split(";")
-        .associate { cookie ->
+    val cookieMap = allCookies?.split(";")
+        ?.mapNotNull { cookie ->
             val parts = cookie.trim().split("=", limit = 2)
-            parts[0].trim() to (parts.getOrNull(1)?.trim() ?: "")
-        }
+            if (parts.size == 2 && parts[0].trim().isNotEmpty()) {
+                parts[0].trim() to parts[1].trim()
+            } else {
+                null
+            }
+        }?.toMap() ?: emptyMap()
 
     val spDc = cookieMap["sp_dc"]
     if (spDc.isNullOrBlank()) {
-        Timber.w("SpotifyLogin: sp_dc not found in cookies: ${cookieMap.keys}")
+        Timber.w("SpotifyLogin: sp_dc not found in cookies (keys: ${cookieMap.keys})")
+        setProcessing(true)
+        setStatus(context.getString(R.string.spotify_login_error_no_cookie))
+        setError(true)
+        tokenFetchStarted.set(false)
         return
     }
 
     val spKey = cookieMap["sp_key"] ?: ""
-    Timber.d("SpotifyLogin: sp_dc found (${spDc.take(8)}...), stopping WebView")
+    Timber.d("SpotifyLogin: sp_dc found (${spDc.take(8)}...), starting token fetch")
 
     setProcessing(true)
+    setError(false)
     setStatus(context.getString(R.string.spotify_status_verifying))
 
     view?.stopLoading()
@@ -240,14 +310,12 @@ private fun extractAndFetchToken(
 
     scope.launch(Dispatchers.IO) {
         try {
-            // Step 1: Save cookies
             context.dataStore.edit { prefs ->
                 prefs[SpotifySpDcKey] = spDc
                 prefs[SpotifySpKeyKey] = spKey
             }
 
-            // Step 2: Fetch access token with TOTP
-            scope.launch(Dispatchers.Main) {
+            withContext(Dispatchers.Main) {
                 setStatus(context.getString(R.string.spotify_status_connecting))
             }
             Timber.d("SpotifyLogin: fetching access token via SpotifyAuth (with TOTP)...")
@@ -256,8 +324,7 @@ private fun extractAndFetchToken(
             Timber.d("SpotifyLogin: token obtained (anonymous=${token.isAnonymous})")
             Spotify.accessToken = token.accessToken
 
-            // Step 3: Fetch user profile
-            scope.launch(Dispatchers.Main) {
+            withContext(Dispatchers.Main) {
                 setStatus(context.getString(R.string.spotify_status_loading_profile))
             }
             Timber.d("SpotifyLogin: fetching user profile...")
@@ -272,27 +339,52 @@ private fun extractAndFetchToken(
                 Timber.w(e, "SpotifyLogin: could not fetch profile (non-fatal)")
             }
 
-            // Step 4: Persist access token — triggers isSpotifyActive in library screens
             context.dataStore.edit { prefs ->
                 prefs[SpotifyAccessTokenKey] = token.accessToken
                 prefs[SpotifyTokenExpiryKey] = token.accessTokenExpirationTimestampMs
             }
 
-            scope.launch(Dispatchers.Main) {
+            withContext(Dispatchers.Main) {
                 setStatus(context.getString(R.string.spotify_login_success))
             }
             Timber.d("SpotifyLogin: login complete, navigating back")
 
-            scope.launch(Dispatchers.Main) {
+            delay(300)
+
+            withContext(Dispatchers.Main) {
                 navController.navigateUp()
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            Timber.e(e, "SpotifyLogin: login failed")
-            scope.launch(Dispatchers.Main) {
-                setStatus(context.getString(R.string.spotify_login_error))
-                setProcessing(false)
+            Timber.e(e, "SpotifyLogin: login failed — ${e.message}")
+            val errorMsg = classifyLoginError(context, e)
+            withContext(Dispatchers.Main) {
+                setStatus(errorMsg)
+                setError(true)
             }
+            tokenFetchStarted.set(false)
         }
+    }
+}
+
+/**
+ * Maps authentication exceptions to user-friendly error messages.
+ */
+private fun classifyLoginError(context: Context, e: Exception): String {
+    val msg = e.message.orEmpty()
+    return when {
+        "anonymous" in msg || "expired" in msg ->
+            context.getString(R.string.spotify_login_error_expired)
+        "HTTP 403" in msg || "HTTP 401" in msg ->
+            context.getString(R.string.spotify_login_error_rejected)
+        "gist" in msg.lowercase() || "nuance" in msg.lowercase() ->
+            context.getString(R.string.spotify_login_error_network)
+        "UnknownHostException" in msg || "timeout" in msg.lowercase() ||
+            "SocketTimeoutException" in e.javaClass.simpleName ->
+            context.getString(R.string.spotify_login_error_network)
+        else ->
+            context.getString(R.string.spotify_login_error)
     }
 }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -468,6 +468,48 @@ fun LibraryPlaylistsScreen(
                         }
                     }
 
+                    // Spotify playlists failed to load banner
+                    if (isSpotifyActive && !needsSpotifyReLogin && isUsingFallback && spotifyPlaylists.isEmpty()) {
+                        item(key = "spotify_load_error_banner") {
+                            androidx.compose.material3.Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                                colors = androidx.compose.material3.CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                                ),
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Icon(
+                                        painterResource(R.drawable.spotify),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                                    )
+                                    Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                                    Text(
+                                        text = stringResource(R.string.spotify_playlists_load_error),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onErrorContainer,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    androidx.compose.material3.TextButton(
+                                        onClick = { spotifyViewModel.loadPlaylists() },
+                                    ) {
+                                        Text(
+                                            text = stringResource(R.string.retry),
+                                            color = MaterialTheme.colorScheme.onErrorContainer,
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // Spotify Liked Songs as a special playlist entry
                     if (isSpotifyActive && spotifyLikedSongsTotal > 0) {
                         item(key = "spotify_liked_songs") {
@@ -708,6 +750,51 @@ fun LibraryPlaylistsScreen(
                                 playlist = playlist,
                                 modifier = Modifier.animateItem()
                             )
+                        }
+                    }
+
+                    // Spotify playlists failed to load banner (grid)
+                    if (isSpotifyActive && !needsSpotifyReLogin && isUsingFallback && spotifyPlaylists.isEmpty()) {
+                        item(
+                            key = "spotify_load_error_banner",
+                            span = { GridItemSpan(maxLineSpan) },
+                        ) {
+                            androidx.compose.material3.Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                                colors = androidx.compose.material3.CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                                ),
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Icon(
+                                        painterResource(R.drawable.spotify),
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onErrorContainer,
+                                    )
+                                    Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                                    Text(
+                                        text = stringResource(R.string.spotify_playlists_load_error),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.onErrorContainer,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                    androidx.compose.material3.TextButton(
+                                        onClick = { spotifyViewModel.loadPlaylists() },
+                                    ) {
+                                        Text(
+                                            text = stringResource(R.string.retry),
+                                            color = MaterialTheme.colorScheme.onErrorContainer,
+                                        )
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/HomeViewModel.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
 import timber.log.Timber
 import java.time.LocalDate
 import javax.inject.Inject
@@ -771,13 +772,24 @@ class HomeViewModel @Inject constructor(
                 ))
             }
 
-            // Section 5: Your Playlists (GQL — no rate limit)
+            // Section 5: Your Playlists (GQL — no rate limit, with cache fallback)
             Spotify.myPlaylists(limit = 10).onSuccess { paging ->
                 if (paging.items.isNotEmpty()) {
                     sections.add(SpotifyHomeSection(
                         title = "spotify_your_playlists",
                         type = SectionType.PLAYLISTS,
                         playlists = paging.items,
+                    ))
+                }
+            }.onFailure { e ->
+                Timber.e(e, "HomeVM: Failed to load Spotify playlists for Home — ${e.message}")
+                val cached = loadCachedPlaylists()
+                if (cached.isNotEmpty()) {
+                    Timber.d("HomeVM: Using ${cached.size} cached playlists as fallback")
+                    sections.add(SpotifyHomeSection(
+                        title = "spotify_your_playlists",
+                        type = SectionType.PLAYLISTS,
+                        playlists = cached.take(10),
                     ))
                 }
             }
@@ -792,6 +804,8 @@ class HomeViewModel @Inject constructor(
                         albums = albums,
                     ))
                 }
+            }.onFailure { e ->
+                Timber.e(e, "HomeVM: Failed to load Spotify new releases — ${e.message}")
             }
 
             // Section 7: Discover — artists not in the top section
@@ -888,6 +902,20 @@ class HomeViewModel @Inject constructor(
             episodesForLater.value = episodes
         }.onFailure {
             reportException(it)
+        }
+    }
+
+    private val playlistCacheJson = Json { ignoreUnknownKeys = true }
+    private val playlistCacheKey = androidx.datastore.preferences.core.stringPreferencesKey("spotify_cached_playlists_json")
+
+    private suspend fun loadCachedPlaylists(): List<SpotifyPlaylist> {
+        return try {
+            val prefs = context.dataStore.data.first()
+            val jsonStr = prefs[playlistCacheKey] ?: return emptyList()
+            playlistCacheJson.decodeFromString<List<SpotifyPlaylist>>(jsonStr)
+        } catch (e: Exception) {
+            Timber.w(e, "HomeVM: failed to load cached playlists")
+            emptyList()
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalFilesViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/LocalFilesViewModel.kt
@@ -6,6 +6,7 @@
 package com.metrolist.music.viewmodels
 
 import android.content.Context
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.provider.MediaStore
 import androidx.lifecycle.ViewModel
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.io.File
 import java.time.LocalDateTime
 import javax.inject.Inject
 
@@ -64,7 +66,7 @@ constructor(
             try {
                 performScan()
             } catch (e: Exception) {
-                Timber.tag("LocalFilesViewModel").e(e, "Error scanning local files")
+                Timber.tag("LocalFilesVM").e(e, "Error scanning local files")
             } finally {
                 _isScanning.value = false
             }
@@ -72,6 +74,8 @@ constructor(
     }
 
     private fun performScan() {
+        val artworkDir = File(context.cacheDir, "artwork").also { it.mkdirs() }
+
         val projection = arrayOf(
             MediaStore.Audio.Media._ID,
             MediaStore.Audio.Media.TITLE,
@@ -109,13 +113,17 @@ constructor(
 
                 val songId = "local:$mediaStoreId"
 
-                // Only insert if not already in DB
                 val existing = database.getSongByIdBlocking(songId)
                 if (existing == null) {
-                        val songEntity = SongEntity(
+                    val thumbnailUri = extractAndCacheArtwork(
+                        contentUri, songId, artworkDir,
+                    )
+
+                    val songEntity = SongEntity(
                         id = songId,
                         title = title,
                         duration = (durationMs / 1000).toInt(),
+                        thumbnailUrl = thumbnailUri,
                         albumName = album,
                         isLocal = true,
                         localPath = contentUri,
@@ -137,11 +145,54 @@ constructor(
                             insert(SongArtistMap(songId = songId, artistId = artistId, position = 0))
                         }
                     }
-                } else if (existing.song.localPath != contentUri) {
-                    // Update path if changed (e.g. file moved)
-                    database.query { setLocalPath(songId, contentUri) }
+                } else {
+                    if (existing.song.localPath != contentUri) {
+                        database.query { setLocalPath(songId, contentUri) }
+                    }
+                    // Backfill artwork for songs that were imported before artwork extraction
+                    if (existing.song.thumbnailUrl == null) {
+                        val thumbnailUri = extractAndCacheArtwork(
+                            contentUri, songId, artworkDir,
+                        )
+                        if (thumbnailUri != null) {
+                            database.query {
+                                upsert(existing.song.copy(thumbnailUrl = thumbnailUri))
+                            }
+                        }
+                    }
                 }
             }
+        }
+    }
+
+    /**
+     * Extracts embedded cover art from a local audio file via its content URI
+     * and saves it to the artwork cache directory. Returns a file:// URI
+     * pointing to the cached image, or null if no artwork is embedded.
+     */
+    private fun extractAndCacheArtwork(
+        contentUri: String,
+        songId: String,
+        artworkDir: File,
+    ): String? {
+        val safeFileName = songId.replace(":", "_") + ".jpg"
+        val artworkFile = File(artworkDir, safeFileName)
+
+        if (artworkFile.exists()) {
+            return Uri.fromFile(artworkFile).toString()
+        }
+
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(context, Uri.parse(contentUri))
+            val artBytes = retriever.embeddedPicture ?: return null
+            artworkFile.writeBytes(artBytes)
+            Uri.fromFile(artworkFile).toString()
+        } catch (e: Exception) {
+            Timber.tag("LocalFilesVM").w(e, "Failed to extract artwork for $songId")
+            null
+        } finally {
+            try { retriever.release() } catch (_: Exception) {}
         }
     }
 }

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/SpotifyViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/SpotifyViewModel.kt
@@ -11,6 +11,8 @@
 package com.metrolist.music.viewmodels
 
 import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.metrolist.music.constants.EnableSpotifyKey
@@ -30,9 +32,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -46,6 +51,8 @@ constructor(
 
     companion object {
         private const val STAGGER_DELAY_MS = 500L
+        private val CACHE_KEY_PLAYLISTS = stringPreferencesKey("spotify_cached_playlists_json")
+        private val jsonSerializer = Json { ignoreUnknownKeys = true; encodeDefaults = true }
     }
 
     val spotifyYouTubeMapper = SpotifyYouTubeMapper(database)
@@ -175,10 +182,16 @@ constructor(
         _playlistsError.value = null
 
         if (!SpotifyTokenManager.ensureAuthenticated()) {
-            Timber.w("SpotifyVM: loadPlaylists() - auth failed")
-            _playlistsError.value = "Not authenticated"
+            Timber.w("SpotifyVM: loadPlaylists() - auth failed, trying cache fallback")
+            val cached = loadPlaylistsFromCache()
+            if (cached.isNotEmpty()) {
+                Timber.d("SpotifyVM: loadPlaylists() - using ${cached.size} cached playlists")
+                _spotifyPlaylists.value = cached
+            } else {
+                _playlistsError.value = "Not authenticated"
+                setFallback("Authentication failed while loading playlists")
+            }
             _playlistsLoading.value = false
-            setFallback("Authentication failed while loading playlists")
             return 0
         }
 
@@ -189,16 +202,50 @@ constructor(
                 Timber.d("SpotifyVM:   playlist: '${pl.name}' (${pl.tracks?.total ?: "?"} tracks)")
             }
             _spotifyPlaylists.value = paging.items
+            savePlaylistsToCache(paging.items)
         }.onFailure { e ->
-            Timber.e(e, "SpotifyVM: loadPlaylists() - FAILED")
-            _playlistsError.value = e.message
+            Timber.e(e, "SpotifyVM: loadPlaylists() - FAILED: ${e.message}")
             retryAfter = (e as? Spotify.SpotifyException)?.retryAfterSec ?: 0
             handleAuthError(e)
-            setFallback("Failed to load playlists: ${e.message}")
+
+            val cached = loadPlaylistsFromCache()
+            if (cached.isNotEmpty()) {
+                Timber.d("SpotifyVM: loadPlaylists() - API failed, using ${cached.size} cached playlists")
+                _spotifyPlaylists.value = cached
+                _playlistsError.value = null
+            } else {
+                _playlistsError.value = e.message
+                setFallback("Failed to load playlists: ${e.message}")
+            }
         }
 
         _playlistsLoading.value = false
         return retryAfter
+    }
+
+    private suspend fun savePlaylistsToCache(playlists: List<SpotifyPlaylist>) {
+        try {
+            val jsonStr = jsonSerializer.encodeToString(playlists)
+            context.dataStore.edit { prefs ->
+                prefs[CACHE_KEY_PLAYLISTS] = jsonStr
+            }
+            Timber.d("SpotifyVM: cached ${playlists.size} playlists to DataStore")
+        } catch (e: Exception) {
+            Timber.w(e, "SpotifyVM: failed to cache playlists")
+        }
+    }
+
+    private suspend fun loadPlaylistsFromCache(): List<SpotifyPlaylist> {
+        return try {
+            val prefs = context.dataStore.data.first()
+            val jsonStr = prefs[CACHE_KEY_PLAYLISTS] ?: return emptyList()
+            val playlists = jsonSerializer.decodeFromString<List<SpotifyPlaylist>>(jsonStr)
+            Timber.d("SpotifyVM: loaded ${playlists.size} playlists from DataStore cache")
+            playlists
+        } catch (e: Exception) {
+            Timber.w(e, "SpotifyVM: failed to load playlists from cache")
+            emptyList()
+        }
     }
 
     /** @return Retry-After seconds if 429 was hit, 0 otherwise */

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -382,6 +382,7 @@
     <string name="spotify_liked_songs">Spotify Liked Songs</string>
     <string name="spotify_session_expired">Spotify session expired. Please log in again.</string>
     <string name="spotify_relogin">Log in again</string>
+    <string name="spotify_playlists_load_error">Failed to load Spotify playlists. This may be a temporary issue.</string>
     <string name="spotify_music_source">Music Source</string>
     <string name="spotify_music_source_description">Choose where to load your library from</string>
     <string name="spotify_source_youtube">YouTube Music</string>
@@ -391,6 +392,10 @@
     <string name="spotify_status_connecting">Obtaining access token…</string>
     <string name="spotify_status_loading_profile">Loading your profile…</string>
     <string name="spotify_login_error">Login failed. Please try again.</string>
+    <string name="spotify_login_error_no_cookie">Could not retrieve session cookie. Please try logging in again.</string>
+    <string name="spotify_login_error_expired">Session expired or invalid. Please log in with your credentials again.</string>
+    <string name="spotify_login_error_rejected">Spotify rejected the request. Please try again later.</string>
+    <string name="spotify_login_error_network">Network error. Please check your connection and try again.</string>
     <string name="spotify_login_success">Connected to Spotify</string>
     <string name="spotify_token_expired">Spotify session expired, please log in again</string>
     <string name="spotify_no_tracks">No tracks found</string>

--- a/spotify/src/main/kotlin/com/metrolist/spotify/SpotifyAuth.kt
+++ b/spotify/src/main/kotlin/com/metrolist/spotify/SpotifyAuth.kt
@@ -98,16 +98,31 @@ object SpotifyAuth {
     }
 
     private suspend fun fetchNuance(): Nuance = withContext(Dispatchers.IO) {
-        val body = httpGet(NUANCE_GIST_URL, emptyMap())
+        val body = try {
+            httpGet(NUANCE_GIST_URL, emptyMap())
+        } catch (e: Exception) {
+            throw Spotify.SpotifyException(
+                503,
+                "Failed to fetch TOTP secret from gist: ${e.message}",
+            )
+        }
         val gist = json.decodeFromString<GistFiles>(body)
-        val nuancesJson = gist.files.values.first().content
+        val nuancesJson = gist.files.values.firstOrNull()?.content
+            ?: throw Spotify.SpotifyException(500, "Gist has no files")
         val nuances = json.decodeFromString<List<Nuance>>(nuancesJson)
         nuances.maxByOrNull { it.v }
             ?: throw Spotify.SpotifyException(500, "No nuance data found in gist")
     }
 
     private suspend fun fetchServerTime(): Long = withContext(Dispatchers.IO) {
-        val body = httpGet(SERVER_TIME_URL, emptyMap())
+        val body = try {
+            httpGet(SERVER_TIME_URL, emptyMap())
+        } catch (e: Exception) {
+            throw Spotify.SpotifyException(
+                503,
+                "Failed to fetch Spotify server time: ${e.message}",
+            )
+        }
         val response = json.decodeFromString<ServerTimeResponse>(body)
         response.serverTime
     }


### PR DESCRIPTION
- Added caching mechanism for Spotify playlists to improve loading reliability and performance.
- Implemented error banners in the LibraryPlaylistsScreen to notify users when Spotify playlists fail to load.
- Updated SpotifyLoginScreen to handle token extraction more robustly and provide user feedback on login errors.
- Introduced artwork extraction and caching for local files to enhance user experience.

## Problem
<!-- Describe the issue or limitation this PR addresses -->

## Cause
<!-- Explain the root cause of the problem -->

## Solution
<!-- List the changes made to fix the issue -->
- 

## Testing
<!-- Describe how the changes were tested -->

Closes #
