### PR TITLE
feat: Added options to hide recognize-music and play-random buttons from homescreen

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/metrolist/music/constants/PreferenceKeys.kt
@@ -269,6 +269,8 @@ val QueueEditLockKey = booleanPreferencesKey("queueEditLock")
 val ShowWrappedCardKey = booleanPreferencesKey("show_wrapped_card")
 val WrappedSeenKey = booleanPreferencesKey("wrapped_seen")
 val LastSeenVersionKey = stringPreferencesKey("lastSeenVersion")
+val ShowRecognizeButtonKey = booleanPreferencesKey("showRecognizeButton")
+val ShowPlayRandomButtonKey = booleanPreferencesKey("showPlayRandomButton")
 val RandomizeHomeOrderKey = booleanPreferencesKey("randomizeHomeOrder")
 
 val ShowLikedPlaylistKey = booleanPreferencesKey("show_liked_playlist")

--- a/app/src/main/kotlin/com/metrolist/music/ui/component/HideOnScrollFAB.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/component/HideOnScrollFAB.kt
@@ -42,7 +42,11 @@ fun BoxScope.HideOnScrollFAB(
     @DrawableRes icon: Int,
     onClick: () -> Unit,
     onRecognitionClick: (() -> Unit)? = null,
+    showRecognition: Boolean = true,
+    showMainAction: Boolean = true,
 ) {
+    if (!showRecognition && !showMainAction) return
+
     AnimatedVisibility(
         visible = visible && lazyListState.isScrollingUp(),
         enter = slideInVertically { it },
@@ -59,28 +63,43 @@ fun BoxScope.HideOnScrollFAB(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(16.dp)
         ) {
-            if (onRecognitionClick != null) {
-                SmallFloatingActionButton(
-                    onClick = onRecognitionClick,
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier.size(40.dp)
+            if (showRecognition && onRecognitionClick != null) {
+                if (showMainAction) {
+                    SmallFloatingActionButton(
+                        onClick = onRecognitionClick,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mic),
+                            contentDescription = stringResource(R.string.recognize_music),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                } else {
+                    FloatingActionButton(
+                        onClick = onRecognitionClick,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mic),
+                            contentDescription = stringResource(R.string.recognize_music),
+                        )
+                    }
+                }
+            }
+            if (showMainAction) {
+                FloatingActionButton(
+                    onClick = onClick,
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.mic),
-                        contentDescription = stringResource(R.string.recognize_music),
-                        modifier = Modifier.size(20.dp)
+                        painter = painterResource(icon),
+                        contentDescription = null,
                     )
                 }
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-            FloatingActionButton(
-                onClick = onClick,
-            ) {
-                Icon(
-                    painter = painterResource(icon),
-                    contentDescription = null,
-                )
             }
         }
     }
@@ -93,7 +112,11 @@ fun BoxScope.HideOnScrollFAB(
     @DrawableRes icon: Int,
     onClick: () -> Unit,
     onRecognitionClick: (() -> Unit)? = null,
+    showRecognition: Boolean = true,
+    showMainAction: Boolean = true,
 ) {
+    if (!showRecognition && !showMainAction) return
+
     AnimatedVisibility(
         visible = visible && lazyListState.isScrollingUp(),
         enter = slideInVertically { it },
@@ -110,28 +133,43 @@ fun BoxScope.HideOnScrollFAB(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(16.dp)
         ) {
-            if (onRecognitionClick != null) {
-                SmallFloatingActionButton(
-                    onClick = onRecognitionClick,
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier.size(40.dp)
+            if (showRecognition && onRecognitionClick != null) {
+                if (showMainAction) {
+                    SmallFloatingActionButton(
+                        onClick = onRecognitionClick,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mic),
+                            contentDescription = stringResource(R.string.recognize_music),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                } else {
+                    FloatingActionButton(
+                        onClick = onRecognitionClick,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mic),
+                            contentDescription = stringResource(R.string.recognize_music),
+                        )
+                    }
+                }
+            }
+            if (showMainAction) {
+                FloatingActionButton(
+                    onClick = onClick,
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.mic),
-                        contentDescription = stringResource(R.string.recognize_music),
-                        modifier = Modifier.size(20.dp)
+                        painter = painterResource(icon),
+                        contentDescription = null,
                     )
                 }
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-            FloatingActionButton(
-                onClick = onClick,
-            ) {
-                Icon(
-                    painter = painterResource(icon),
-                    contentDescription = null,
-                )
             }
         }
     }
@@ -144,7 +182,11 @@ fun BoxScope.HideOnScrollFAB(
     @DrawableRes icon: Int,
     onClick: () -> Unit,
     onRecognitionClick: (() -> Unit)? = null,
+    showRecognition: Boolean = true,
+    showMainAction: Boolean = true,
 ) {
+    if (!showRecognition && !showMainAction) return
+
     AnimatedVisibility(
         visible = visible && scrollState.isScrollingUp(),
         enter = slideInVertically { it },
@@ -161,28 +203,43 @@ fun BoxScope.HideOnScrollFAB(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier.padding(16.dp)
         ) {
-            if (onRecognitionClick != null) {
-                SmallFloatingActionButton(
-                    onClick = onRecognitionClick,
-                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-                    modifier = Modifier.size(40.dp)
+            if (showRecognition && onRecognitionClick != null) {
+                if (showMainAction) {
+                    SmallFloatingActionButton(
+                        onClick = onRecognitionClick,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        modifier = Modifier.size(40.dp)
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mic),
+                            contentDescription = stringResource(R.string.recognize_music),
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                } else {
+                    FloatingActionButton(
+                        onClick = onRecognitionClick,
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.mic),
+                            contentDescription = stringResource(R.string.recognize_music),
+                        )
+                    }
+                }
+            }
+            if (showMainAction) {
+                FloatingActionButton(
+                    onClick = onClick,
                 ) {
                     Icon(
-                        painter = painterResource(R.drawable.mic),
-                        contentDescription = stringResource(R.string.recognize_music),
-                        modifier = Modifier.size(20.dp)
+                        painter = painterResource(icon),
+                        contentDescription = null,
                     )
                 }
-                Spacer(modifier = Modifier.height(12.dp))
-            }
-            FloatingActionButton(
-                onClick = onClick,
-            ) {
-                Icon(
-                    painter = painterResource(icon),
-                    contentDescription = null,
-                )
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/HomeScreen.kt
@@ -116,6 +116,8 @@ import com.metrolist.music.constants.InnerTubeCookieKey
 import com.metrolist.music.constants.ListItemHeight
 import com.metrolist.music.constants.ListThumbnailSize
 import com.metrolist.music.constants.RandomizeHomeOrderKey
+import com.metrolist.music.constants.ShowPlayRandomButtonKey
+import com.metrolist.music.constants.ShowRecognizeButtonKey
 import com.metrolist.music.constants.SmallGridThumbnailHeight
 import com.metrolist.music.constants.ThumbnailCornerRadius
 import com.metrolist.music.db.entities.Album
@@ -780,6 +782,9 @@ fun HomeScreen(
 
     // Track randomization job
     var randomizeJob by remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+
+    val (showRecognizeButton) = rememberPreference(ShowRecognizeButtonKey, defaultValue = true)
+    val (showPlayRandomButton) = rememberPreference(ShowPlayRandomButtonKey, defaultValue = true)
 
     val lazylistState = rememberLazyListState()
     val gridItemSize by rememberEnumPreference(GridItemsSizeKey, GridItemSize.BIG)
@@ -2864,6 +2869,8 @@ fun HomeScreen(
                 onRecognitionClick = {
                     navController.navigate("recognition")
                 },
+                showRecognition = showRecognizeButton,
+                showMainAction = showPlayRandomButton,
             )
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AppearanceSettings.kt
@@ -91,6 +91,8 @@ import com.metrolist.music.constants.SelectedThemeColorKey
 import com.metrolist.music.constants.ShowCachedPlaylistKey
 import com.metrolist.music.constants.ShowDownloadedPlaylistKey
 import com.metrolist.music.constants.ShowLikedPlaylistKey
+import com.metrolist.music.constants.ShowPlayRandomButtonKey
+import com.metrolist.music.constants.ShowRecognizeButtonKey
 import com.metrolist.music.constants.ShowTopPlaylistKey
 import com.metrolist.music.constants.ShowUploadedPlaylistKey
 import com.metrolist.music.constants.SliderStyle
@@ -177,6 +179,17 @@ fun AppearanceSettings(
             UseNewPlayerDesignKey,
             defaultValue = true,
         )
+    val (showRecognizeButton, onShowRecognizeButtonChange) =
+        rememberPreference(
+            ShowRecognizeButtonKey,
+            defaultValue = true,
+        )
+    val (showPlayRandomButton, onShowPlayRandomButtonChange) =
+        rememberPreference(
+            ShowPlayRandomButtonKey,
+            defaultValue = true,
+        )
+
     val (miniPlayerBackground, onMiniPlayerBackgroundChange) =
         rememberEnumPreference(
             MiniPlayerBackgroundStyleKey,
@@ -1718,6 +1731,50 @@ fun AppearanceSettings(
                             )
                         },
                         onClick = { onListenTogetherInTopBarChange(!listenTogetherInTopBar) },
+                    ),
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.mic),
+                        title = { Text(stringResource(R.string.show_recognize_music_button)) },
+                        description = { Text(stringResource(R.string.show_recognize_music_button_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = showRecognizeButton,
+                                onCheckedChange = onShowRecognizeButtonChange,
+                                thumbContent = {
+                                    Icon(
+                                        painter =
+                                            painterResource(
+                                                id = if (showRecognizeButton) R.drawable.check else R.drawable.close,
+                                            ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                    )
+                                },
+                            )
+                        },
+                        onClick = { onShowRecognizeButtonChange(!showRecognizeButton) },
+                    ),
+                    Material3SettingsItem(
+                        icon = painterResource(R.drawable.shuffle),
+                        title = { Text(stringResource(R.string.show_play_random_button)) },
+                        description = { Text(stringResource(R.string.show_play_random_button_desc)) },
+                        trailingContent = {
+                            Switch(
+                                checked = showPlayRandomButton,
+                                onCheckedChange = onShowPlayRandomButtonChange,
+                                thumbContent = {
+                                    Icon(
+                                        painter =
+                                            painterResource(
+                                                id = if (showPlayRandomButton) R.drawable.check else R.drawable.close,
+                                            ),
+                                        contentDescription = null,
+                                        modifier = Modifier.size(SwitchDefaults.IconSize),
+                                    )
+                                },
+                            )
+                        },
+                        onClick = { onShowPlayRandomButtonChange(!showPlayRandomButton) },
                     ),
                     Material3SettingsItem(
                         icon = painterResource(R.drawable.grid_view),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -230,6 +230,10 @@
     <string name="misc">Misc</string>
     <string name="default_open_tab">Default open tab</string>
     <string name="grid_cell_size">Grid cell size</string>
+    <string name="show_recognize_music_button">Show music recognition button</string>
+    <string name="show_recognize_music_button_desc">Show the music recognition button on the home screen</string>
+    <string name="show_play_random_button">Show play random button</string>
+    <string name="show_play_random_button_desc">Show the play random button on the home screen</string>
     <string name="small">Small</string>
     <string name="big">Big</string>
 

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-04T07:02:49Z",
-  "bundle_id": "web-player.26f8b0e1.js",
+  "last_updated": "2026-05-05T06:46:42Z",
+  "bundle_id": "web-player.8b596a66.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-04T07:02:49Z",
+      "last_verified": "2026-05-05T06:46:42Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-12T06:59:14Z",
-  "bundle_id": "web-player.7300fdff.js",
+  "last_updated": "2026-05-13T07:03:15Z",
+  "bundle_id": "web-player.8f5f0604.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-12T06:59:14Z",
+      "last_verified": "2026-05-13T07:03:15Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-05T06:46:42Z",
-  "bundle_id": "web-player.8b596a66.js",
+  "last_updated": "2026-05-06T06:58:48Z",
+  "bundle_id": "web-player.b44cc6f2.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-05T06:46:42Z",
+      "last_verified": "2026-05-06T06:58:48Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-07T07:00:13Z",
-  "bundle_id": "web-player.56b958f6.js",
+  "last_updated": "2026-05-08T06:37:07Z",
+  "bundle_id": "web-player.423b2c61.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-07T07:00:13Z",
+      "last_verified": "2026-05-08T06:37:07Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-11T07:12:24Z",
-  "bundle_id": "web-player.94fe2e70.js",
+  "last_updated": "2026-05-12T06:59:14Z",
+  "bundle_id": "web-player.7300fdff.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-11T07:12:24Z",
+      "last_verified": "2026-05-12T06:59:14Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-09T06:44:08Z",
-  "bundle_id": "web-player.3a16da82.js",
+  "last_updated": "2026-05-10T06:55:31Z",
+  "bundle_id": "web-player.6d385abd.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-09T06:44:08Z",
+      "last_verified": "2026-05-10T06:55:31Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-08T06:37:07Z",
-  "bundle_id": "web-player.423b2c61.js",
+  "last_updated": "2026-05-09T06:44:08Z",
+  "bundle_id": "web-player.3a16da82.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-08T06:37:07Z",
+      "last_verified": "2026-05-09T06:44:08Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-06T06:58:48Z",
-  "bundle_id": "web-player.b44cc6f2.js",
+  "last_updated": "2026-05-07T07:00:13Z",
+  "bundle_id": "web-player.56b958f6.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-06T06:58:48Z",
+      "last_verified": "2026-05-07T07:00:13Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-10T06:55:31Z",
-  "bundle_id": "web-player.6d385abd.js",
+  "last_updated": "2026-05-11T07:12:24Z",
+  "bundle_id": "web-player.94fe2e70.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-10T06:55:31Z",
+      "last_verified": "2026-05-11T07:12:24Z",
       "last_changed": null
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-14T07:01:10Z",
-  "bundle_id": "web-player.99cffed6.js",
+  "last_updated": "2026-05-15T07:07:19Z",
+  "bundle_id": "web-player.068c7554.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,7 +112,7 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
@@ -120,7 +120,7 @@
       "previous_hash": "23e37f2e58d82d567f27080101d36609009d8c3676457b1086cb0acc55b72a5d",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-14T07:01:10Z",
+      "last_verified": "2026-05-15T07:07:19Z",
       "last_changed": "2026-05-14T07:01:10Z"
     }
   }

--- a/docs/spotify-gql-hashes.json
+++ b/docs/spotify-gql-hashes.json
@@ -1,14 +1,14 @@
 {
   "schema_version": 1,
-  "last_updated": "2026-05-13T07:03:15Z",
-  "bundle_id": "web-player.8f5f0604.js",
+  "last_updated": "2026-05-14T07:01:10Z",
+  "bundle_id": "web-player.99cffed6.js",
   "operations": {
     "profileAttributes": {
       "hash": "53bcb064f6cd18c23f752bc324a791194d20df612d8e1239c735144ab0399ced",
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": null
     },
     "libraryV3": {
@@ -16,7 +16,7 @@
       "previous_hash": "2de10199b2441d6e4ae875f27d2db361020c399fb10b03951120223fbed10b08",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "fetchPlaylist": {
@@ -24,7 +24,7 @@
       "previous_hash": "32b05e92e438438408674f95d0fdad8082865dc32acd55bd97f5113b8579092b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "fetchLibraryTracks": {
@@ -32,7 +32,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": null
     },
     "searchDesktop": {
@@ -48,7 +48,7 @@
       "previous_hash": "586081a84a994057edfebca11d4af5e7efeae2d7948f8d9175b20be14124949f",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": "2026-04-15T06:38:02Z"
     },
     "getAlbum": {
@@ -56,7 +56,7 @@
       "previous_hash": null,
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": null
     },
     "queryWhatsNewFeed": {
@@ -64,7 +64,7 @@
       "previous_hash": "3b53dede3c6054e8b7c962dd280eb6761c5d1c82b06b039f4110d76a62b4966b",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": "2026-03-31T06:30:04Z"
     },
     "addToPlaylist": {
@@ -72,7 +72,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": null
     },
     "removeFromPlaylist": {
@@ -80,7 +80,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": null
     },
     "moveItemsInPlaylist": {
@@ -88,7 +88,7 @@
       "previous_hash": null,
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": null
     },
     "editPlaylistAttributes": {
@@ -104,7 +104,7 @@
       "previous_hash": "d4e8489ed1e97e655e23d54e77f97bcaa0cfd2bab9484d9a31f94f94e0bf38d2",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "removeFromLibrary": {
@@ -112,16 +112,16 @@
       "previous_hash": "a2f87a82a05f01cf5e8df9c29eab5e25a4b1ba9e26c43be21cd9a4ad2c2b24db",
       "type": "mutation",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
+      "last_verified": "2026-05-14T07:01:10Z",
       "last_changed": "2026-03-23T00:00:00Z"
     },
     "home": {
-      "hash": "23e37f2e58d82d567f27080101d36609009d8c3676457b1086cb0acc55b72a5d",
-      "previous_hash": null,
+      "hash": "40c1423fc26ea0d68cd8f212e79ca47df7968fc40d83d184e756af54fd043143",
+      "previous_hash": "23e37f2e58d82d567f27080101d36609009d8c3676457b1086cb0acc55b72a5d",
       "type": "query",
       "status": "verified",
-      "last_verified": "2026-05-13T07:03:15Z",
-      "last_changed": null
+      "last_verified": "2026-05-14T07:01:10Z",
+      "last_changed": "2026-05-14T07:01:10Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
Adds two toggle settings under Appearance that allow users to show or hide the Music Recognition and Random Play floating action buttons on the home screen.

This is just an enhancement PR. Music Recognition is already available in the search tab, so this helps keep the home screen a bit cleaner if needed. Also, since Random Play isn’t for everyone, this gives users the option to turn it off.


## Testing
<!-- Describe how the changes were tested -->
Build and tested