### PR TITLE
fix: swap player/streaming poToken — real 403 cause

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/potoken/PoTokenGenerator.kt
@@ -3,10 +3,12 @@ package com.metrolist.music.utils.potoken
 import android.webkit.CookieManager
 import com.metrolist.music.utils.cipher.CipherDeobfuscator
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import timber.log.Timber
 
 class PoTokenGenerator {
@@ -29,8 +31,33 @@ class PoTokenGenerator {
         }
 
         return try {
-            Timber.tag(TAG).d("Calling runBlocking to generate poToken...")
-            runBlocking { getWebClientPoToken(videoId, sessionId, forceRecreate = false) }
+            Timber.tag(TAG).d("Calling runBlocking to generate poToken (timeout=${POTOKEN_TIMEOUT_MS}ms)...")
+            runBlocking {
+                withTimeout(POTOKEN_TIMEOUT_MS) {
+                    getWebClientPoToken(videoId, sessionId, forceRecreate = false)
+                }
+            }
+        } catch (e: TimeoutCancellationException) {
+            // The WebView's sandboxed process can be culled by the OS (storage pressure, low
+            // memory, etc.) which leaves the PoToken WebView call hung indefinitely. Cap it so
+            // playerResponseForPlayback can fall through to non-PoToken fallback clients (e.g.
+            // ANDROID_VR) instead of blocking the entire playback path.
+            Timber.tag(TAG).w("poToken generation timed out after ${POTOKEN_TIMEOUT_MS}ms; proceeding without PoToken")
+            runBlocking {
+                webPoTokenGenLock.withLock {
+                    try {
+                        withContext(Dispatchers.Main) {
+                            webPoTokenGenerator?.close()
+                        }
+                    } catch (closeEx: Exception) {
+                        Timber.tag(TAG).e(closeEx, "Exception closing PoTokenWebView during timeout cleanup")
+                    }
+                    webPoTokenGenerator = null
+                    webPoTokenStreamingPot = null
+                    webPoTokenSessionId = null
+                }
+            }
+            null
         } catch (e: Exception) {
             Timber.tag(TAG).e(e, "poToken generation exception: ${e.javaClass.simpleName}: ${e.message}")
             when (e) {
@@ -42,6 +69,13 @@ class PoTokenGenerator {
                 else -> throw e // includes PoTokenException
             }
         }
+    }
+
+    private companion object {
+        // Healthy cold-start (WebView spin-up + botguard JS + token gen) is ~2–5s in practice;
+        // 8s leaves slack for a slow device without making the user wait too long before the
+        // fallback chain (ANDROID_VR, etc.) takes over when the WebView hangs.
+        const val POTOKEN_TIMEOUT_MS = 8_000L
     }
 
     /**
@@ -93,8 +127,11 @@ class PoTokenGenerator {
             }
         }
 
-        Timber.tag(TAG).d("poToken generated successfully: player=${playerPot.take(20)}..., streaming=${streamingPot.take(20)}...")
+        Timber.tag(TAG).d("poToken generated successfully: session=${streamingPot.take(20)}..., video=${playerPot.take(20)}...")
 
-        return PoTokenResult(playerPot, streamingPot)
+        return PoTokenResult(
+            playerRequestPoToken = streamingPot,
+            streamingDataPoToken = playerPot,
+        )
     }
 }


### PR DESCRIPTION
## Problem
Certain tracks fail to play with a recurring **HTTP 403 I/O error** on the stream, while the same tracks play fine upstream in Metrolist. Track metadata loads correctly, but the actual `videoplayback` (googlevideo CDN) request is rejected. Reproducible example: `https://youtu.be/66hXbqNn51o` (Macklemore — Otherside).

## Cause
The two WebView/BotGuard poTokens were **swapped** when constructing `PoTokenResult` in `PoTokenGenerator`:

- `playerRequestPoToken` (sent in the `/player` API request) and `streamingDataPoToken` (appended as `pot=` to the stream URL the CDN validates) were assigned to each other's values.
- Result: the `pot=` token on the stream URL was the token YouTube expected on the *other* request, so the CDN returned **403** even though the `/player` response was valid. This explains why metadata loaded but playback failed, and why it was track/rollout dependent.

## Solution
- Assign the poTokens to the correct fields in `PoTokenGenerator.getWebClientPoToken()`:
  - `playerRequestPoToken = streamingPot` (session-bound → `/player` request)
  - `streamingDataPoToken = playerPot` (videoId-bound → `pot=` on the stream URL)
- Add an 8s `withTimeout` guard around poToken generation so a hung/OS-culled PoToken WebView no longer blocks the playback path — it now falls through to non-poToken fallback clients (e.g. `ANDROID_VR`) and tears down the stale WebView/session state.

## Testing
- Built a debug APK from the `dev` branch via CI and installed on a physical device.
- Played `https://youtu.be/66hXbqNn51o` (previously 403'd): now plays successfully.
- Verified previously-working tracks continue to play (no regressions) and that playback recovers cleanly when poToken generation times out.

## Related Issues
- Closes #
- Related to #

---
> **Provenance:** The corrected poToken field mapping and the `withTimeout` WebView-hang guard mirror the implementation in upstream [Metrolist](https://github.com/MetrolistGroup/Metrolist) (`PoTokenGenerator.kt`), which does not exhibit this 403. This PR brings our fork's poToken handling in line with upstream.

Please review and merge asap, can mark all 403 related bugs as solved! 