### PR TITLE
merge - fix: stop on task clear (#181) + correct Spotify Liked Songs play order (#202)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -153,6 +153,7 @@ import com.metrolist.music.constants.ShufflePlaylistFirstKey
 import com.metrolist.music.constants.SimilarContent
 import com.metrolist.music.constants.SkipSilenceInstantKey
 import com.metrolist.music.constants.SkipSilenceKey
+import com.metrolist.music.constants.StopMusicOnTaskClearKey
 import com.metrolist.music.db.MusicDatabase
 import com.metrolist.music.db.entities.Event
 import com.metrolist.music.db.entities.FormatEntity
@@ -3983,6 +3984,14 @@ class MusicService :
     override fun onBind(intent: Intent?) = super.onBind(intent) ?: binder
 
     override fun onTaskRemoved(rootIntent: Intent?) {
+        // When the app is swiped away from recents, a foreground media service keeps the
+        // process (and playback) alive, so relying on MainActivity.onDestroy is unreliable.
+        // Android guarantees this callback, so honor "Stop music on task clear" here: halt
+        // playback immediately and tear the service down (onDestroy persists queue/state).
+        if (playerInitialized.value && dataStore.get(StopMusicOnTaskClearKey, false)) {
+            player.stop()
+            stopSelf()
+        }
         super.onTaskRemoved(rootIntent)
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/queues/SpotifyLikedSongsQueue.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/queues/SpotifyLikedSongsQueue.kt
@@ -29,6 +29,13 @@ class SpotifyLikedSongsQueue(
     private val startIndex: Int = 0,
     private val mapper: SpotifyYouTubeMapper,
     override val preloadItem: MediaMetadata? = null,
+    /**
+     * Pre-ordered list of tracks to play, matching exactly what the UI displays (after
+     * the user's sort/reverse). When provided, [startIndex] indexes into THIS list and no
+     * Spotify pagination happens, so playback order always matches the visible list.
+     * When null, the queue falls back to fetching from the Spotify API in its native order.
+     */
+    private val tracks: List<SpotifyTrack>? = null,
 ) : Queue {
 
     companion object {
@@ -52,15 +59,29 @@ class SpotifyLikedSongsQueue(
 
     override suspend fun getInitialStatus(): Queue.Status = withContext(Dispatchers.IO) {
         try {
-            val result = Spotify.likedSongs(limit = SPOTIFY_PAGE_SIZE, offset = 0).getOrThrow()
-            apiTotal = result.total
-            val fetched = result.items.map { it.track }.filter { !it.isLocal }
-            allTracks.addAll(fetched)
-            apiFetchOffset = result.items.size
-            apiHasMore = apiFetchOffset < apiTotal
+            val provided = tracks
+            if (provided != null) {
+                // Play the exact list (and order) the UI is showing.
+                allTracks.clear()
+                allTracks.addAll(provided.filter { !it.isLocal })
+                apiTotal = allTracks.size
+                apiFetchOffset = allTracks.size
+                apiHasMore = false
+            } else {
+                val result = Spotify.likedSongs(limit = SPOTIFY_PAGE_SIZE, offset = 0).getOrThrow()
+                apiTotal = result.total
+                val fetched = result.items.map { it.track }.filter { !it.isLocal }
+                allTracks.addAll(fetched)
+                apiFetchOffset = result.items.size
+                apiHasMore = apiFetchOffset < apiTotal
 
-            while (startIndex >= allTracks.size && apiHasMore) {
-                fetchNextApiPage()
+                while (startIndex >= allTracks.size && apiHasMore) {
+                    fetchNextApiPage()
+                }
+            }
+
+            if (allTracks.isEmpty()) {
+                return@withContext Queue.Status(title = null, items = emptyList(), mediaItemIndex = 0)
             }
 
             val targetIndex = startIndex.coerceIn(0, (allTracks.size - 1).coerceAtLeast(0))
@@ -103,20 +124,30 @@ class SpotifyLikedSongsQueue(
 
     override suspend fun getFullStatus(): Queue.Status? = withContext(Dispatchers.IO) {
         try {
-            // Build full list from scratch so we always include tracks 0..N (not just from startIndex onwards)
-            allTracks.clear()
-            apiFetchOffset = 0
-            apiHasMore = true
-            while (apiFetchOffset == 0 || apiHasMore) {
-                if (apiFetchOffset == 0) {
-                    val result = Spotify.likedSongs(limit = SPOTIFY_PAGE_SIZE, offset = 0).getOrThrow()
-                    apiTotal = result.total
-                    val fetched = result.items.map { it.track }.filter { !it.isLocal }
-                    allTracks.addAll(fetched)
-                    apiFetchOffset = result.items.size
-                    apiHasMore = apiFetchOffset < apiTotal
-                } else {
-                    fetchNextApiPage()
+            val provided = tracks
+            if (provided != null) {
+                // Use the exact UI-provided order; no pagination needed.
+                allTracks.clear()
+                allTracks.addAll(provided.filter { !it.isLocal })
+                apiTotal = allTracks.size
+                apiFetchOffset = allTracks.size
+                apiHasMore = false
+            } else {
+                // Build full list from scratch so we always include tracks 0..N (not just from startIndex onwards)
+                allTracks.clear()
+                apiFetchOffset = 0
+                apiHasMore = true
+                while (apiFetchOffset == 0 || apiHasMore) {
+                    if (apiFetchOffset == 0) {
+                        val result = Spotify.likedSongs(limit = SPOTIFY_PAGE_SIZE, offset = 0).getOrThrow()
+                        apiTotal = result.total
+                        val fetched = result.items.map { it.track }.filter { !it.isLocal }
+                        allTracks.addAll(fetched)
+                        apiFetchOffset = result.items.size
+                        apiHasMore = apiFetchOffset < apiTotal
+                    } else {
+                        fetchNextApiPage()
+                    }
                 }
             }
             if (allTracks.isEmpty()) return@withContext null

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/SpotifyLikedSongsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/SpotifyLikedSongsScreen.kt
@@ -227,6 +227,7 @@ fun SpotifyLikedSongsScreen(
                                         SpotifyLikedSongsQueue(
                                             startIndex = 0,
                                             mapper = viewModel.mapper,
+                                            tracks = sortedTracks,
                                         )
                                     )
                                 },
@@ -353,6 +354,7 @@ fun SpotifyLikedSongsScreen(
                                     SpotifyLikedSongsQueue(
                                         startIndex = originalIndex,
                                         mapper = viewModel.mapper,
+                                        tracks = sortedTracks,
                                     )
                                 )
                             },


### PR DESCRIPTION
Fixes two self-contained bugs.

## #181 — Stop Music On Task Clear isn't working
`MusicService.onTaskRemoved()` was empty. With a foreground media service the process (and playback) stays alive when the app is swiped from recents, and `MainActivity.onDestroy` (which depends on `isFinishing`) is not a reliable place to stop it. `onTaskRemoved` is the callback Android guarantees in that scenario, so the "Stop music on task clear" setting is now honored there: `player.stop()` + `stopSelf()`.

## #202 — Spotify Liked Songs "upside down"
The list is rendered from `sortedTracks` (reversed by default, `sortDescending = true`), but `SpotifyLikedSongsQueue` re-fetched from the Spotify API in its **native order** and interpreted `startIndex` against that order. So tapping row 0 (the last API track) started playback at API track 0 — the mirrored song. Exactly the reported symptom.

Fix: the queue now takes an optional pre-ordered `tracks: List<SpotifyTrack>?`. The screen passes the same ordered list it displays, so playback order == visible order and `startIndex` indexes the same list. When no list is provided it falls back to the previous API-fetch behavior (backward compatible).

**Note:** playback order now snapshots the UI list at tap time — if you tap while pages are still loading, the queue holds what's currently visible (previously the queue repopulated from the API independently). This is more consistent with "what you see is what plays".

## Testing
Not built locally (Android SDK/JDK toolchain not set up in this environment). Changes are minimal and isolated; please build a debug APK via CI and verify:
- #181: enable "Stop music on task clear", play, swipe app from recents → audio stops.
- #202: open Spotify Liked Songs, tap the first row → the first visible track plays (not the last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)