### PR TITLE
merge - fix: stats crash, blurry Spotify art, ducking volume jump, boot autostart

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/db/entities/SongWithStats.kt
+++ b/app/src/main/kotlin/com/metrolist/music/db/entities/SongWithStats.kt
@@ -25,7 +25,7 @@ data class SongWithStats(
         )
     )
     val artists: List<ArtistEntity>,
-    val thumbnailUrl: String,
+    val thumbnailUrl: String?,
     val artistName: String?,
     val songCountListened: Int,
     val timeListened: Long?,

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -1214,7 +1214,11 @@ class MusicService :
             }
 
             AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
-                hasAudioFocus = false
+                // We still HOLD audio focus while ducking — the system only asks us to lower our
+                // volume, not to give up focus. Keeping hasAudioFocus = true prevents the player
+                // event handler from re-requesting AUDIOFOCUS_GAIN, which caused a focus ping-pong
+                // with the foreground app and snapped our volume from 0.2 back to 1.0 (issue #116).
+                hasAudioFocus = true
                 audioFocusVolumeMultiplier.value = 0.2f
                 wasPlayingBeforeAudioFocusLoss = player.isPlaying
                 if (player.isPlaying) {

--- a/app/src/main/kotlin/com/metrolist/music/playback/alarm/MusicAlarmScheduler.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/alarm/MusicAlarmScheduler.kt
@@ -11,6 +11,11 @@ import java.util.Calendar
 object MusicAlarmScheduler {
     fun scheduleFromPreferences(context: Context) {
         val alarms = MusicAlarmStore.loadBlocking(context)
+        // Nothing to (re)schedule when the alarm feature isn't in use. Bailing out here avoids
+        // waking the app process and writing to DataStore on every BOOT_COMPLETED broadcast when
+        // the user never set up an alarm (see issue #32). After a reboot AlarmManager entries are
+        // cleared by the system anyway, so there is nothing to cancel in that case.
+        if (alarms.none { it.enabled && it.playlistId.isNotBlank() }) return
         scheduleAll(context, alarms)
     }
 

--- a/spotify/src/main/kotlin/com/metrolist/spotify/SpotifyMapper.kt
+++ b/spotify/src/main/kotlin/com/metrolist/spotify/SpotifyMapper.kt
@@ -80,10 +80,12 @@ object SpotifyMapper {
 
     /**
      * Returns the best thumbnail URL from a Spotify track's album art.
+     * Prefers the highest available resolution so the full-screen player cover isn't blurry
+     * (Spotify CDN URLs cannot be up-scaled via resize(), so the source variant must be large).
      */
     fun getTrackThumbnail(track: SpotifyTrack): String? {
         return track.album?.images?.let { images ->
-            images.firstOrNull { it.width in 200..400 }?.url
+            images.maxByOrNull { it.width ?: 0 }?.url
                 ?: images.firstOrNull()?.url
         }
     }


### PR DESCRIPTION
Batch of four independent bug fixes. Each is small and self-contained.

## Fixes

### `Fixes #166` — Stats screen crash
`SongWithStats.thumbnailUrl` was declared non-null (`String`) while the underlying `song.thumbnailUrl` column is nullable. Room threw a `NullPointerException` while building the projection whenever a most-played song had no thumbnail (common for locally-imported or not-yet-fetched tracks), crashing the Stats screen. Made the field nullable to match the schema — the only consumer (`LocalSongsGrid`) already accepts a nullable url.

### `Fixes #186` — Blurry album art (Spotify)
`SpotifyMapper.getTrackThumbnail` selected the ~300px image variant (`width in 200..400`), and `resize()` has no branch for Spotify's `i.scdn.co` CDN, so the full-screen player up-scaled a 300px image → visibly soft. Now selects the largest available variant (up to 640px).

### `Fixes #116` — Sudden volume jump when another app plays in foreground
The `AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK` handler wrongly set `hasAudioFocus = false`. Since the app manages audio focus manually, the player-event handler then re-requested `AUDIOFOCUS_GAIN` on the next timeline event, causing a focus ping-pong with the foreground app that snapped the volume from the ducked `0.2` back to `1.0`. We still hold focus while ducking, so keep `hasAudioFocus = true`.

### `Fixes #32` — App auto-starts / does background work after reboot
`MusicAlarmRescheduleReceiver` ran on every `BOOT_COMPLETED` and called `scheduleFromPreferences`, which does blocking DataStore reads/writes even when the user never configured an alarm. Now bails out early when there is no enabled alarm (after a reboot AlarmManager entries are cleared anyway, so there is nothing to cancel).

## Testing
`./gradlew :app:compileFossDebugKotlin :spotify:compileKotlin` → BUILD SUCCESSFUL (after `git submodule update --init metroproto` + `app/generate_proto.sh`, as CI does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)