### PR TITLE
fix(ui): resolve low quality album cover artwork in player

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/player/Thumbnail.kt
@@ -72,6 +72,7 @@ import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
+import coil3.size.Size
 import com.metrolist.music.LocalListenTogetherManager
 import com.metrolist.music.LocalPlayerConnection
 import com.metrolist.music.R
@@ -654,6 +655,7 @@ private fun ThumbnailImage(
         SubcomposeAsyncImage(
             model = ImageRequest.Builder(LocalContext.current)
                 .data(currentUri)
+                .size(Size(1080, 1080))
                 .memoryCachePolicy(CachePolicy.ENABLED)
                 .diskCachePolicy(CachePolicy.ENABLED)
                 .networkCachePolicy(CachePolicy.ENABLED)

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -13,16 +13,17 @@ fun String.resize(
     width: Int? = null,
     height: Int? = null,
 ): String {
-    if (width == null && height == null) return this
-    "https://lh3\\.googleusercontent\\.com/.*=w(\\d+)-h(\\d+).*".toRegex()
-        .matchEntire(this)?.groupValues?.let { group ->
-        val (W, H) = group.drop(1).map { it.toInt() }
-        var w = width
-        var h = height
-        if (w != null && h == null) h = (w / W) * H
-        if (w == null && h != null) w = (h / H) * W
-        return "${split("=w")[0]}=w$w-h$h-p-l90-rj"
+    val host = runCatching { java.net.URI(this).host }.getOrNull()
+        ?: this.substringAfter("://").substringBefore("/").substringBefore(":")
+    // Google-hosted artwork (lh3..lh6, yt3.googleusercontent.com)
+    // Note: 544px is standard high-res resolution for YouTube Music square artwork
+    if (host.endsWith("googleusercontent.com", ignoreCase = true)) {
+        val baseUrl = this.substringBefore("=")
+        val w = width ?: height ?: 544
+        val h = height ?: width ?: 544
+        return "$baseUrl=w$w-h$h-p-l90-rj"
     }
+    if (width == null && height == null) return this
     if (this matches "https://yt3\\.ggpht\\.com/.*=s(\\d+)".toRegex()) {
         return "$this-s${width ?: height}"
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/utils/YouTubeUtils.kt
@@ -5,6 +5,8 @@
 
 package com.metrolist.music.ui.utils
 
+import java.net.URI
+
 private val YT_VIDEO_THUMB_PATTERN =
     "https?://i\\.ytimg\\.com/(vi|vi_webp)/([^/]+)/([a-z0-9_]+)\\.(jpg|webp)(\\?.*)?"
         .toRegex(RegexOption.IGNORE_CASE)
@@ -13,7 +15,7 @@ fun String.resize(
     width: Int? = null,
     height: Int? = null,
 ): String {
-    val host = runCatching { java.net.URI(this).host }.getOrNull()
+    val host = runCatching { URI(this).host }.getOrNull()
         ?: this.substringAfter("://").substringBefore("/").substringBefore(":")
     // Google-hosted artwork (lh3..lh6, yt3.googleusercontent.com)
     // Note: 544px is standard high-res resolution for YouTube Music square artwork


### PR DESCRIPTION
## Problem
Album cover artwork displayed in the expanded fullscreen player view appears blurry and low-resolution on high-DPI displays (reported in #215 and #220). Additionally, artwork hosted across various Google CDN subdomains (e.g., `yt3.googleusercontent.com`, `lh3`–`lh6.googleusercontent.com`) was not matched by the previous URL parameter rewrite logic, resulting in downscaled fallback assets being served.

## Cause
1. **Coil Container Downsampling**: Coil defaults to downsampling loaded images based on container constraints when no explicit `Size` policy is specified in `ImageRequest.Builder`.
2. **Strict Regex Host Matching**: The previous matching logic in `YouTubeUtils.kt` relied on a regex restricted to `lh3.googleusercontent.com`, bypassing other valid Google CDN subdomains.
3. **Early Return Guard**: An early `width == null && height == null` guard in `YouTubeUtils.kt` was preventing unparameterized `googleusercontent.com` URLs from resolving to the default high-res `544px` square resolution.

## Solution
- **High-Res Resolution Request**: Integrated `import coil3.size.Size` and added `.size(Size(1080, 1080))` to `ImageRequest.Builder` within `Thumbnail.kt` to request high-resolution decoding while capping memory bounds against potential OOMs on large local assets.
- **Subdomain-Agnostic Host Matching**: Refactored `YouTubeUtils.kt` to use `URI` host parsing with fallback port-stripping (`host.endsWith("googleusercontent.com", ignoreCase = true)`), ensuring all Google-hosted square artwork endpoints consistently receive high-res query parameters (`=w544-h544-p-l90-rj` / `=w1080-h1080-p-l90-rj`).

## Testing
- Executed `./gradlew :app:testFossDebugUnitTest` (all unit tests passed).
- Executed `./gradlew :app:assembleFossDebug` successfully.
- Executed `./gradlew :app:assembleFossRelease` successfully (verified production release compilation, R8 shrinking, and resources).

## Related Issues
- Closes #215
- Closes #220