### PR TITLE
fix(lastfm): surface ignored scrobbles and finalize playback scrobbling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+**
+
+!Dockerfile
+!docker-compose.yml
+!.dockerignore
+!docker-entrypoint.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,262 @@
+# Contributing to Meld
+
+Meld is an Android/Kotlin music client based on Jetpack Compose and Material 3. This guide describes the recommended local setup and validation flow for contributors.
+
+## 1. Requirements
+
+Recommended:
+
+- Git
+- Docker and Docker Compose
+
+Optional local setup, if you do not use Docker:
+
+- JDK 21
+- Android Studio with Android SDK Platform 36
+- Android SDK Build-Tools 36.0.0
+- Android SDK Platform-Tools
+- Android SDK Command-line Tools
+- `protoc` 3.21 or newer, with `protoc` 34.0 matching CI
+
+The Gradle wrapper is committed, so installing Gradle globally is not required.
+
+## 2. Branch Workflow
+
+Start from an up-to-date `main` branch:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+Create a dedicated branch:
+
+```bash
+git checkout -b feat/short-description
+```
+
+Branch prefixes:
+
+- `fix/` for bug fixes
+- `feat/` for new features
+- `ref/` for refactoring
+- `docs/` for documentation
+- `chore/` for maintenance work
+
+Commit messages should follow:
+
+```text
+type(scope): short description
+```
+
+Examples:
+
+```text
+feat(player): add queue shuffle action
+fix(spotify): handle empty playlist images
+chore(build): update docker dev environment
+```
+
+## 3. Docker Development Environment
+
+Build the development image:
+
+```bash
+docker compose build dev
+```
+
+Open a shell in the container:
+
+```bash
+docker compose run --rm dev bash
+```
+
+The container includes:
+
+- JDK 21
+- Android SDK Platform 36
+- Android Build-Tools 36.0.0
+- Android Platform-Tools
+- `protoc` 34.0
+- Git and basic shell tools
+
+Gradle and Android user caches are stored in Docker volumes so repeated builds do not download everything again.
+
+## 4. Initial Project Setup
+
+Initialize the public protobuf submodule:
+
+```bash
+git submodule update --init metroproto
+```
+
+Generate protobuf sources:
+
+```bash
+cd app
+bash generate_proto.sh
+cd ..
+```
+
+The private notes submodule is optional and requires repository access:
+
+```text
+notes/
+```
+
+Do not recreate the private notes contents if the submodule is empty.
+
+## 5. Optional Debug Keystore
+
+Debug builds can use the default Android debug keystore. If you need a stable project-local debug keystore, generate one with:
+
+```bash
+keytool -genkeypair -v \
+  -keystore app/persistent-debug.keystore \
+  -storepass android \
+  -keypass android \
+  -alias androiddebugkey \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000 \
+  -dname "CN=Android Debug,O=Android,C=US"
+```
+
+This file is ignored by Git.
+
+## 6. Optional Local Secrets
+
+Most development builds work without secrets. Some integrations may be disabled or incomplete unless credentials are provided.
+
+To configure local secrets, copy the sample file and fill in only the values you need:
+
+```bash
+cp local.properties.sample local.properties
+```
+
+`local.properties` is ignored by Git. You can also export these values as environment variables instead:
+
+```properties
+LASTFM_API_KEY=...
+LASTFM_SECRET=...
+CRASH_REPORT_REPO=francescograzioso/Meld
+CRASH_REPORT_TOKEN=...
+```
+
+Release signing secrets are maintained by the project maintainers and are not needed for normal contribution work.
+
+## 7. Build Variants
+
+Main app variants:
+
+- `foss`: default contribution target, no Google Play Services cast support
+- `gms`: includes Google Cast support
+- `izzy`: store-oriented variant with updater disabled
+
+Use `fossDebug` for normal development unless your change specifically targets Google Cast or IzzyOnDroid behavior.
+
+## 8. Validation Commands
+
+Run the same fast checks used by pull request CI:
+
+```bash
+./gradlew --console=plain \
+  :app:testFossDebugUnitTest \
+  :spotify:test \
+  :betterlyrics:test \
+  --warning-mode summary
+```
+
+Build and lint the default debug APK:
+
+```bash
+./gradlew --console=plain \
+  assembleFossDebug \
+  :app:lintFossDebug \
+  --warning-mode summary
+```
+
+The debug APK is generated at:
+
+```text
+app/build/outputs/apk/foss/debug/app-foss-debug.apk
+```
+
+With Docker, prefix the Gradle command:
+
+```bash
+docker compose run --rm dev ./gradlew --console=plain assembleFossDebug
+```
+
+To only build the APK needed for manual testing, run:
+
+```bash
+docker compose run --rm dev ./gradlew --console=plain :app:assembleFossDebug --warning-mode summary
+```
+
+## 9. APK Types
+
+For day-to-day testing, use the debug APK:
+
+```bash
+docker compose run --rm dev ./gradlew --console=plain :app:assembleFossDebug --warning-mode summary
+```
+
+The debug APK is signed with a local Android debug keystore, has `BuildConfig.DEBUG = true`, and is meant for fast install/test cycles. In this project it uses the debug application id suffix, so it can usually be installed next to a release build.
+
+To generate a release APK without maintainer signing keys, run:
+
+```bash
+docker compose run --rm dev ./gradlew --console=plain :app:assembleFossRelease --warning-mode summary
+```
+
+The unsigned release APK is generated at:
+
+```text
+app/build/outputs/apk/foss/release/app-foss-release-unsigned.apk
+```
+
+This APK is minified and optimized like a release build, but it is not installable as-is on a normal Android device until it is signed. Official signed release APKs are produced by maintainers through the release workflow.
+
+## 10. Codebase Notes
+
+Main modules:
+
+- `app`: Android application, Compose UI, playback, database, settings
+- `innertube`: YouTube Music / InnerTube integration
+- `spotify`: Spotify integration and mapping logic
+- `lastfm`: Last.fm integration
+- `betterlyrics`, `lrclib`, `kugou`, `shazamkit`, `paxsenix`, `kizzy`: supporting service integrations
+
+Strings:
+
+- Edit `app/src/main/res/values/metrolist_strings.xml` for source strings.
+- Do not edit `app/src/main/res/values/strings.xml` for app text.
+- Do not edit translated `metrolist_strings.xml` files directly unless the task is explicitly about translations.
+
+Versioning:
+
+- Do not bump `versionCode` or `versionName` during normal contribution work.
+
+Spotify GraphQL hashes:
+
+- If a new Spotify GraphQL operation is added in `spotify/src/main/kotlin`, add it to `docs/spotify-gql-hashes.json` so the scheduled hash checker tracks it.
+
+## 11. Manual Testing
+
+After a successful build, install the APK on a device or emulator:
+
+```bash
+adb install -r app/build/outputs/apk/foss/debug/app-foss-debug.apk
+```
+
+For playback-related work, test at least:
+
+- App launch
+- Search
+- Starting playback
+- Pause/resume
+- Background playback
+- Notification controls
+
+For battery-sensitive playback behavior, test on a physical device when possible.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+
+FROM eclipse-temurin:21-jdk-jammy
+
+ARG ANDROID_COMMANDLINE_TOOLS_VERSION=13114758
+ARG ANDROID_PLATFORM=android-36
+ARG ANDROID_BUILD_TOOLS=36.0.0
+ARG PROTOC_VERSION=34.0
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+ENV ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    GRADLE_USER_HOME=/home/dev/.gradle \
+    PATH=/opt/android-sdk/cmdline-tools/latest/bin:/opt/android-sdk/platform-tools:/opt/android-sdk/build-tools/${ANDROID_BUILD_TOOLS}:/usr/local/bin:${PATH}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        openssh-client \
+        unzip \
+        zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" /tmp/android-sdk \
+    && curl -fsSL \
+        "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_COMMANDLINE_TOOLS_VERSION}_latest.zip" \
+        -o /tmp/android-commandline-tools.zip \
+    && unzip -q /tmp/android-commandline-tools.zip -d /tmp/android-sdk \
+    && mv /tmp/android-sdk/cmdline-tools "${ANDROID_HOME}/cmdline-tools/latest" \
+    && rm -rf /tmp/android-sdk /tmp/android-commandline-tools.zip \
+    && yes | sdkmanager --licenses >/dev/null \
+    && sdkmanager \
+        "platform-tools" \
+        "platforms;${ANDROID_PLATFORM}" \
+        "build-tools;${ANDROID_BUILD_TOOLS}"
+
+RUN curl -fsSL \
+        "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+        -o /tmp/protoc.zip \
+    && unzip -q /tmp/protoc.zip -d /usr/local \
+    && rm /tmp/protoc.zip
+
+RUN groupadd --gid "${GROUP_ID}" dev \
+    && useradd --uid "${USER_ID}" --gid "${GROUP_ID}" --create-home --shell /bin/bash dev \
+    && mkdir -p /workspace "${GRADLE_USER_HOME}" /home/dev/.android \
+    && chown -R dev:dev /workspace /home/dev
+
+COPY --chown=dev:dev docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+USER dev
+WORKDIR /workspace
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["bash"]

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -933,14 +933,18 @@ class MusicService :
                     val minSongDuration =
                         dataStore.get(ScrobbleMinSongDurationKey, LastFM.DEFAULT_SCROBBLE_MIN_SONG_DURATION)
                     val delaySeconds = dataStore.get(ScrobbleDelaySecondsKey, LastFM.DEFAULT_SCROBBLE_DELAY_SECONDS)
-                    scrobbleManager =
+                    val manager =
                         ScrobbleManager(
                             scope,
                             minSongDuration = minSongDuration,
                             scrobbleDelayPercent = delayPercent,
                             scrobbleDelaySeconds = delaySeconds,
                         )
-                    scrobbleManager?.useNowPlaying = dataStore.get(LastFMUseNowPlaying, false)
+                    scrobbleManager = manager
+                    manager.useNowPlaying = dataStore.get(LastFMUseNowPlaying, false)
+                    if (::player.isInitialized && player.isPlaying) {
+                        manager.onSongStart(player.currentMetadata, duration = player.duration)
+                    }
                 } else if (!enabled && scrobbleManager != null) {
                     scrobbleManager?.destroy()
                     scrobbleManager = null
@@ -2396,8 +2400,17 @@ class MusicService :
         }
 
         // Scrobbling
-        if (events.containsAny(Player.EVENT_IS_PLAYING_CHANGED)) {
-            scrobbleManager?.onPlayerStateChanged(player.isPlaying, player.currentMetadata, duration = player.duration)
+        if (events.containsAny(
+                Player.EVENT_IS_PLAYING_CHANGED,
+                Player.EVENT_PLAYBACK_STATE_CHANGED,
+                Player.EVENT_MEDIA_ITEM_TRANSITION,
+            )
+        ) {
+            scrobbleManager?.onPlayerStateChanged(
+                player.isPlaying,
+                player.currentMetadata,
+                duration = player.duration,
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -2204,7 +2204,7 @@ class MusicService :
         // Restart SponsorBlock for the new track (no-op when disabled).
         startSponsorBlockForCurrentTrack()
 
-        scrobbleManager?.onSongStop()
+        scrobbleManager?.onSongStop(finalize = reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO)
         if (player.playWhenReady && player.playbackState == Player.STATE_READY) {
             scrobbleManager?.onSongStart(player.currentMetadata, duration = player.duration)
         }
@@ -2292,7 +2292,9 @@ class MusicService :
             scheduleCrossfade()
         }
 
-        if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
+        if (playbackState == Player.STATE_ENDED) {
+            scrobbleManager?.onSongStop(finalize = true)
+        } else if (playbackState == Player.STATE_IDLE) {
             scrobbleManager?.onSongStop()
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavController
 import com.metrolist.lastfm.LastFM
+import com.metrolist.music.BuildConfig
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.R
 import com.metrolist.music.constants.EnableLastFMScrobblingKey
@@ -121,6 +122,7 @@ fun LastFMSettings(
     var showLoginDialog by rememberSaveable { mutableStateOf(false) }
     var isLoggingIn by rememberSaveable { mutableStateOf(false) }
     var loginError by rememberSaveable { mutableStateOf<String?>(null) }
+    val lastFmApiCredentialsMissingError = stringResource(R.string.lastfm_api_credentials_missing)
 
     if (showLoginDialog) {
         var tempUsername by rememberSaveable { mutableStateOf("") }
@@ -198,6 +200,10 @@ fun LastFMSettings(
                     onClick = {
                         if (tempUsername.isBlank() || tempPassword.isBlank()) {
                             loginError = "Please enter both username and password"
+                            return@TextButton
+                        }
+                        if (BuildConfig.LASTFM_API_KEY.isBlank() || BuildConfig.LASTFM_SECRET.isBlank()) {
+                            loginError = lastFmApiCredentialsMissingError
                             return@TextButton
                         }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
@@ -26,21 +26,26 @@ class ScrobbleManager(
     private var scrobbleTimerStartedAt: Long = 0L
     private var songStartedAt: Long = 0L
     private var songStarted = false
+    private var currentMetadata: MediaMetadata? = null
+    private var currentSongDuration = 0
+    private var currentSongScrobbled = false
     var useNowPlaying = true
 
     fun destroy() {
         scrobbleJob?.cancel()
-        scrobbleRemainingMillis = 0L
-        scrobbleTimerStartedAt = 0L
-        songStartedAt = 0L
-        songStarted = false
+        resetCurrentSong()
     }
 
     fun onSongStart(metadata: MediaMetadata?, duration: Long? = null) {
         if (metadata == null) return
-        songStartedAt = System.currentTimeMillis() / 1000
+        val startedAt = System.currentTimeMillis() / 1000
+        val durationSeconds = resolveDuration(metadata, duration)
+        songStartedAt = startedAt
         songStarted = true
-        startScrobbleTimer(metadata, duration)
+        currentMetadata = metadata
+        currentSongDuration = durationSeconds
+        currentSongScrobbled = false
+        startScrobbleTimer(metadata, durationSeconds, startedAt)
         if (useNowPlaying) {
             updateNowPlaying(metadata)
         }
@@ -54,32 +59,36 @@ class ScrobbleManager(
         pauseScrobbleTimer()
     }
 
-    fun onSongStop() {
+    fun onSongStop(finalize: Boolean = false) {
+        if (finalize || hasReachedScrobbleThreshold()) {
+            scrobbleCurrentSongIfNeeded()
+        }
         stopScrobbleTimer()
-        songStarted = false
+        resetCurrentSong()
     }
 
-    private fun startScrobbleTimer(metadata: MediaMetadata, duration: Long? = null) {
+    private fun startScrobbleTimer(
+        metadata: MediaMetadata,
+        duration: Int,
+        startedAt: Long = songStartedAt
+    ) {
         scrobbleJob?.cancel()
-        val duration = when {
-            duration == null || duration == C.TIME_UNSET || duration <= 0 -> metadata.duration
-            else -> (duration / 1000).toInt()
-        }
-
         if (duration <= minSongDuration) return
 
         val threshold = duration * 1000L * scrobbleDelayPercent
         scrobbleRemainingMillis = min(threshold.toLong(), scrobbleDelaySeconds * 1000L)
 
         if (scrobbleRemainingMillis <= 0) {
-            scrobbleSong(metadata)
+            scrobbleSongIfNeeded(metadata, startedAt)
             return
         }
         scrobbleTimerStartedAt = System.currentTimeMillis()
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
-            scrobbleSong(metadata)
+            scrobbleSongIfNeeded(metadata, startedAt)
             scrobbleJob = null
+            scrobbleRemainingMillis = 0L
+            scrobbleTimerStartedAt = 0L
         }
     }
 
@@ -100,8 +109,10 @@ class ScrobbleManager(
         scrobbleTimerStartedAt = System.currentTimeMillis()
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
-            scrobbleSong(metadata)
+            scrobbleSongIfNeeded(metadata, songStartedAt)
             scrobbleJob = null
+            scrobbleRemainingMillis = 0L
+            scrobbleTimerStartedAt = 0L
         }
     }
 
@@ -111,21 +122,68 @@ class ScrobbleManager(
         scrobbleRemainingMillis = 0
     }
 
-    private fun scrobbleSong(metadata: MediaMetadata) {
+    private fun hasReachedScrobbleThreshold(): Boolean {
+        if (currentSongDuration <= minSongDuration || currentSongScrobbled) return false
+        return remainingScrobbleMillis() <= 0L
+    }
+
+    private fun remainingScrobbleMillis(): Long =
+        if (scrobbleTimerStartedAt == 0L) {
+            scrobbleRemainingMillis
+        } else {
+            scrobbleRemainingMillis - (System.currentTimeMillis() - scrobbleTimerStartedAt)
+        }
+
+    private fun scrobbleCurrentSongIfNeeded() {
+        val metadata = currentMetadata ?: return
+        if (currentSongDuration <= minSongDuration) return
+        scrobbleSongIfNeeded(metadata, songStartedAt)
+    }
+
+    private fun scrobbleSongIfNeeded(metadata: MediaMetadata, startedAt: Long) {
+        if (currentSongScrobbled || startedAt <= 0L) return
+        currentSongScrobbled = true
+        scrobbleSong(metadata, startedAt)
+    }
+
+    private fun scrobbleSong(metadata: MediaMetadata, startedAt: Long) {
         scope.launch {
             val artist = metadata.artists.joinToString { it.name }
             LastFM.scrobble(
                 artist = artist,
                 track = metadata.title,
                 duration = metadata.duration,
-                timestamp = songStartedAt,
+                timestamp = startedAt,
                 album = metadata.album?.title,
             ).onSuccess {
                 Timber.d("Last.fm: scrobbled \"${metadata.title}\" by $artist")
             }.onFailure { e ->
-                Timber.w(e, "Last.fm: scrobble failed for \"${metadata.title}\" by $artist")
+                if (e is LastFM.LastFmIgnoredException) {
+                    Timber.w(
+                        "Last.fm: scrobble ignored for \"${metadata.title}\" by $artist " +
+                            "(code ${e.ignoredCode}): ${e.message}"
+                    )
+                } else {
+                    Timber.w(e, "Last.fm: scrobble failed for \"${metadata.title}\" by $artist")
+                }
             }
         }
+    }
+
+    private fun resolveDuration(metadata: MediaMetadata, duration: Long? = null): Int =
+        when {
+            duration == null || duration == C.TIME_UNSET || duration <= 0 -> metadata.duration
+            else -> (duration / 1000).toInt()
+        }
+
+    private fun resetCurrentSong() {
+        scrobbleRemainingMillis = 0L
+        scrobbleTimerStartedAt = 0L
+        songStartedAt = 0L
+        songStarted = false
+        currentMetadata = null
+        currentSongDuration = 0
+        currentSongScrobbled = false
     }
 
     private fun updateNowPlaying(metadata: MediaMetadata) {
@@ -136,7 +194,14 @@ class ScrobbleManager(
                 album = metadata.album?.title,
                 duration = metadata.duration,
             ).onFailure { e ->
-                Timber.w(e, "Last.fm: updateNowPlaying failed for \"${metadata.title}\"")
+                if (e is LastFM.LastFmIgnoredException) {
+                    Timber.w(
+                        "Last.fm: updateNowPlaying ignored for \"${metadata.title}\" " +
+                            "(code ${e.ignoredCode}): ${e.message}"
+                    )
+                } else {
+                    Timber.w(e, "Last.fm: updateNowPlaying failed for \"${metadata.title}\"")
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
@@ -20,6 +20,7 @@ class ScrobbleManager(
     var minSongDuration: Int = LastFM.DEFAULT_SCROBBLE_MIN_SONG_DURATION,
     var scrobbleDelayPercent: Float = LastFM.DEFAULT_SCROBBLE_DELAY_PERCENT,
     var scrobbleDelaySeconds: Int = LastFM.DEFAULT_SCROBBLE_DELAY_SECONDS,
+    private val client: LastFmScrobbleClient = LastFmScrobbleClient.Default,
 ) {
     private var scrobbleJob: Job? = null
     private var scrobbleRemainingMillis: Long = 0L
@@ -47,7 +48,7 @@ class ScrobbleManager(
         currentSongScrobbled = false
         startScrobbleTimer(metadata, durationSeconds, startedAt)
         if (useNowPlaying) {
-            updateNowPlaying(metadata)
+            updateNowPlaying(metadata, durationSeconds)
         }
     }
 
@@ -79,13 +80,13 @@ class ScrobbleManager(
         scrobbleRemainingMillis = min(threshold.toLong(), scrobbleDelaySeconds * 1000L)
 
         if (scrobbleRemainingMillis <= 0) {
-            scrobbleSongIfNeeded(metadata, startedAt)
+            scrobbleSongIfNeeded(metadata, startedAt, duration)
             return
         }
         scrobbleTimerStartedAt = System.currentTimeMillis()
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
-            scrobbleSongIfNeeded(metadata, startedAt)
+            scrobbleSongIfNeeded(metadata, startedAt, duration)
             scrobbleJob = null
             scrobbleRemainingMillis = 0L
             scrobbleTimerStartedAt = 0L
@@ -109,7 +110,7 @@ class ScrobbleManager(
         scrobbleTimerStartedAt = System.currentTimeMillis()
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
-            scrobbleSongIfNeeded(metadata, songStartedAt)
+            scrobbleSongIfNeeded(metadata, songStartedAt, currentSongDuration)
             scrobbleJob = null
             scrobbleRemainingMillis = 0L
             scrobbleTimerStartedAt = 0L
@@ -137,22 +138,30 @@ class ScrobbleManager(
     private fun scrobbleCurrentSongIfNeeded() {
         val metadata = currentMetadata ?: return
         if (currentSongDuration <= minSongDuration) return
-        scrobbleSongIfNeeded(metadata, songStartedAt)
+        scrobbleSongIfNeeded(metadata, songStartedAt, currentSongDuration)
     }
 
-    private fun scrobbleSongIfNeeded(metadata: MediaMetadata, startedAt: Long) {
+    private fun scrobbleSongIfNeeded(
+        metadata: MediaMetadata,
+        startedAt: Long,
+        duration: Int,
+    ) {
         if (currentSongScrobbled || startedAt <= 0L) return
         currentSongScrobbled = true
-        scrobbleSong(metadata, startedAt)
+        scrobbleSong(metadata, startedAt, duration)
     }
 
-    private fun scrobbleSong(metadata: MediaMetadata, startedAt: Long) {
+    private fun scrobbleSong(
+        metadata: MediaMetadata,
+        startedAt: Long,
+        duration: Int,
+    ) {
         scope.launch {
             val artist = metadata.artists.joinToString { it.name }
-            LastFM.scrobble(
+            client.scrobble(
                 artist = artist,
                 track = metadata.title,
-                duration = metadata.duration,
+                duration = duration.takeIf { it > 0 },
                 timestamp = startedAt,
                 album = metadata.album?.title,
             ).onSuccess {
@@ -186,13 +195,13 @@ class ScrobbleManager(
         currentSongScrobbled = false
     }
 
-    private fun updateNowPlaying(metadata: MediaMetadata) {
+    private fun updateNowPlaying(metadata: MediaMetadata, duration: Int) {
         scope.launch {
-            LastFM.updateNowPlaying(
+            client.updateNowPlaying(
                 artist = metadata.artists.joinToString { it.name },
                 track = metadata.title,
                 album = metadata.album?.title,
-                duration = metadata.duration,
+                duration = duration.takeIf { it > 0 },
             ).onFailure { e ->
                 if (e is LastFM.LastFmIgnoredException) {
                     Timber.w(
@@ -209,7 +218,10 @@ class ScrobbleManager(
     fun onPlayerStateChanged(isPlaying: Boolean, metadata: MediaMetadata?, duration: Long? = null) {
         if (metadata == null) return
         if (isPlaying) {
-            if (!songStarted) {
+            if (!songStarted || currentMetadata?.id != metadata.id) {
+                if (songStarted) {
+                    onSongStop()
+                }
                 onSongStart(metadata, duration)
             } else {
                 onSongResume(metadata)
@@ -217,5 +229,52 @@ class ScrobbleManager(
         } else {
             onSongPause()
         }
+    }
+}
+
+interface LastFmScrobbleClient {
+    suspend fun updateNowPlaying(
+        artist: String,
+        track: String,
+        album: String? = null,
+        duration: Int? = null,
+    ): Result<Unit>
+
+    suspend fun scrobble(
+        artist: String,
+        track: String,
+        timestamp: Long,
+        album: String? = null,
+        duration: Int? = null,
+    ): Result<Unit>
+
+    object Default : LastFmScrobbleClient {
+        override suspend fun updateNowPlaying(
+            artist: String,
+            track: String,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> =
+            LastFM.updateNowPlaying(
+                artist = artist,
+                track = track,
+                album = album,
+                duration = duration,
+            )
+
+        override suspend fun scrobble(
+            artist: String,
+            track: String,
+            timestamp: Long,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> =
+            LastFM.scrobble(
+                artist = artist,
+                track = track,
+                duration = duration,
+                timestamp = timestamp,
+                album = album,
+            )
     }
 }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -410,6 +410,7 @@
     <string name="lastfm_integration">Last.fm integration</string>
     <string name="enable_scrobbling">Enable scrobbling</string>
     <string name="lastfm_now_playing">Send Now Playing status</string>
+    <string name="lastfm_api_credentials_missing">Last.fm API credentials are missing from this build.</string>
     <string name="last_fm_send_likes">Sync Loved and Unloved</string>
     <string name="last_fm_send_likes_description">Love or unlove songs in Last.fm when you like or unlike them in Meld</string>
     <string name="logging_in">Logging in…</string>

--- a/app/src/test/kotlin/com/metrolist/music/utils/ScrobbleManagerTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/ScrobbleManagerTest.kt
@@ -1,0 +1,78 @@
+package com.metrolist.music.utils
+
+import com.metrolist.music.models.MediaMetadata
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScrobbleManagerTest {
+
+    @Test
+    fun `playing metadata change restarts scrobble timer for the new song`() = runBlocking {
+        val client = FakeLastFmScrobbleClient()
+        val manager = ScrobbleManager(
+            scope = this,
+            minSongDuration = 1,
+            scrobbleDelayPercent = 0.02f,
+            scrobbleDelaySeconds = 10,
+            client = client,
+        )
+
+        manager.onPlayerStateChanged(
+            isPlaying = true,
+            metadata = mediaMetadata(id = "first", title = "First"),
+            duration = 10_000L,
+        )
+        delay(50)
+
+        manager.onPlayerStateChanged(
+            isPlaying = true,
+            metadata = mediaMetadata(id = "second", title = "Second", duration = -1),
+            duration = 10_000L,
+        )
+        delay(300)
+
+        assertEquals(listOf(FakeScrobble(track = "Second", duration = 10)), client.scrobbles)
+
+        manager.destroy()
+    }
+
+    private fun mediaMetadata(
+        id: String,
+        title: String,
+        duration: Int = 10,
+    ) = MediaMetadata(
+        id = id,
+        title = title,
+        artists = listOf(MediaMetadata.Artist(id = null, name = "Artist")),
+        duration = duration,
+    )
+
+    private class FakeLastFmScrobbleClient : LastFmScrobbleClient {
+        val scrobbles = mutableListOf<FakeScrobble>()
+
+        override suspend fun updateNowPlaying(
+            artist: String,
+            track: String,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> = Result.success(Unit)
+
+        override suspend fun scrobble(
+            artist: String,
+            track: String,
+            timestamp: Long,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> {
+            scrobbles += FakeScrobble(track = track, duration = duration)
+            return Result.success(Unit)
+        }
+    }
+
+    private data class FakeScrobble(
+        val track: String,
+        val duration: Int?,
+    )
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        USER_ID: ${UID:-1000}
+        GROUP_ID: ${GID:-1000}
+    image: meld-android-dev:local
+    working_dir: /workspace
+    stdin_open: true
+    tty: true
+    environment:
+      ANDROID_HOME: /opt/android-sdk
+      ANDROID_SDK_ROOT: /opt/android-sdk
+      GRADLE_USER_HOME: /home/dev/.gradle
+      LASTFM_API_KEY: ${LASTFM_API_KEY:-}
+      LASTFM_SECRET: ${LASTFM_SECRET:-}
+      CRASH_REPORT_REPO: ${CRASH_REPORT_REPO:-francescograzioso/Meld}
+      CRASH_REPORT_TOKEN: ${CRASH_REPORT_TOKEN:-}
+      METROLIST_APPLICATION_ID: ${METROLIST_APPLICATION_ID:-}
+      METROLIST_APP_NAME: ${METROLIST_APP_NAME:-}
+    volumes:
+      - .:/workspace
+      - gradle-cache:/home/dev/.gradle
+      - android-user-cache:/home/dev/.android
+    command: bash
+
+volumes:
+  gradle-cache:
+  android-user-cache:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+debug_keystore="${HOME}/.android/debug.keystore"
+
+if [[ ! -f "${debug_keystore}" ]]; then
+  mkdir -p "$(dirname "${debug_keystore}")"
+  keytool -genkeypair -v \
+    -keystore "${debug_keystore}" \
+    -storepass android \
+    -keypass android \
+    -alias androiddebugkey \
+    -keyalg RSA \
+    -keysize 2048 \
+    -validity 10000 \
+    -dname "CN=Android Debug,O=Android,C=US" >/dev/null
+fi
+
+exec "$@"

--- a/lastfm/src/main/kotlin/com/metrolist/lastfm/LastFM.kt
+++ b/lastfm/src/main/kotlin/com/metrolist/lastfm/LastFM.kt
@@ -14,6 +14,12 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import java.security.MessageDigest
 
 object LastFM {
@@ -116,11 +122,20 @@ object LastFM {
         override fun toString(): String = "LastFmException(code=$code, message=$message)"
     }
 
+    class LastFmIgnoredException(
+        val method: String,
+        val ignoredCode: Int,
+        override val message: String
+    ) : Exception(message) {
+        override fun toString(): String =
+            "LastFmIgnoredException(method=$method, ignoredCode=$ignoredCode, message=$message)"
+    }
+
     suspend fun updateNowPlaying(
         artist: String, track: String,
         album: String? = null, trackNumber: Int? = null, duration: Int? = null
     ) = runCatching {
-        client.post {
+        val response = client.post {
             lastfmParams(
                 method = "track.updateNowPlaying",
                 apiKey = API_KEY,
@@ -136,13 +151,18 @@ object LastFM {
             )
             parameter("format", "json")
         }
+        validateLastFmResponse(
+            method = "track.updateNowPlaying",
+            responseText = response.bodyAsText(),
+            statusCode = response.status.value,
+        )
     }
 
     suspend fun scrobble(
         artist: String, track: String, timestamp: Long,
         album: String? = null, trackNumber: Int? = null, duration: Int? = null
     ) = runCatching {
-        client.post {
+        val response = client.post {
             lastfmParams(
                 method = "track.scrobble",
                 apiKey = API_KEY,
@@ -159,6 +179,11 @@ object LastFM {
             )
             parameter("format", "json")
         }
+        validateLastFmResponse(
+            method = "track.scrobble",
+            responseText = response.bodyAsText(),
+            statusCode = response.status.value,
+        )
     }
 
     suspend fun setLoveStatus(
@@ -195,6 +220,95 @@ object LastFM {
     }
 
     fun isInitialized(): Boolean = API_KEY.isNotEmpty() && SECRET.isNotEmpty()
+
+    internal fun validateLastFmResponse(
+        method: String,
+        responseText: String,
+        statusCode: Int = 200
+    ) {
+        val root = runCatching { json.parseToJsonElement(responseText).jsonObject }
+            .getOrElse {
+                if (statusCode !in 200..299) {
+                    throw LastFmException(statusCode, "Last.fm $method failed with HTTP $statusCode")
+                }
+                throw LastFmException(-1, "Last.fm $method returned an invalid response")
+            }
+
+        root.intValue("error")?.let { code ->
+            throw LastFmException(code, root.stringValue("message") ?: "Last.fm $method failed")
+        }
+
+        if (statusCode !in 200..299) {
+            throw LastFmException(statusCode, "Last.fm $method failed with HTTP $statusCode")
+        }
+
+        when (method) {
+            "track.scrobble" -> {
+                val scrobbles = root["scrobbles"]?.jsonObjectOrNull()
+                    ?: throw LastFmException(-1, "Last.fm $method returned an invalid response")
+                validateScrobbleResult(scrobbles)
+            }
+
+            "track.updateNowPlaying" -> {
+                val nowPlaying = root["nowplaying"]?.jsonObjectOrNull()
+                    ?: throw LastFmException(-1, "Last.fm $method returned an invalid response")
+                nowPlaying.findIgnoredMessage()?.throwIfIgnored(method)
+            }
+        }
+    }
+
+    private fun validateScrobbleResult(scrobbles: JsonObject) {
+        val ignoredCount = scrobbles["@attr"]
+            ?.jsonObjectOrNull()
+            ?.intValue("ignored")
+            ?: 0
+
+        val ignoredMessage = scrobbles["scrobble"]
+            ?.asIterable()
+            ?.mapNotNull { it.jsonObjectOrNull()?.findIgnoredMessage() }
+            ?.firstOrNull { it.code != 0 }
+
+        if (ignoredCount > 0) {
+            (ignoredMessage ?: IgnoredMessage(code = -1, message = "Last.fm ignored the scrobble"))
+                .throwIfIgnored("track.scrobble")
+        }
+    }
+
+    private fun JsonObject.findIgnoredMessage(): IgnoredMessage? {
+        val ignoredMessage = this["ignoredMessage"]?.jsonObjectOrNull()
+            ?: this["ignoredmessage"]?.jsonObjectOrNull()
+            ?: return null
+
+        return IgnoredMessage(
+            code = ignoredMessage.intValue("code") ?: 0,
+            message = ignoredMessage.stringValue("#text")
+                ?: ignoredMessage.stringValue("text")
+                ?: ignoredMessage.stringValue("message")
+                ?: "Last.fm ignored the request"
+        )
+    }
+
+    private fun IgnoredMessage.throwIfIgnored(method: String) {
+        if (code == 0) return
+        throw LastFmIgnoredException(method, code, message.ifBlank { "Last.fm ignored the request" })
+    }
+
+    private fun JsonElement.asIterable(): List<JsonElement> =
+        runCatching { jsonArray.toList() }.getOrElse { listOf(this) }
+
+    private fun JsonElement.jsonObjectOrNull(): JsonObject? =
+        runCatching { jsonObject }.getOrNull()
+
+    private fun JsonObject.stringValue(key: String): String? =
+        (this[key] as? JsonPrimitive)?.contentOrNull
+
+    private fun JsonObject.intValue(key: String): Int? =
+        stringValue(key)?.toIntOrNull()
+
+    private data class IgnoredMessage(
+        val code: Int,
+        val message: String
+    )
 
     const val DEFAULT_SCROBBLE_DELAY_PERCENT = 0.5f
     const val DEFAULT_SCROBBLE_MIN_SONG_DURATION = 30

--- a/lastfm/src/test/kotlin/com/metrolist/lastfm/LastFMResponseTest.kt
+++ b/lastfm/src/test/kotlin/com/metrolist/lastfm/LastFMResponseTest.kt
@@ -1,0 +1,99 @@
+package com.metrolist.lastfm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class LastFMResponseTest {
+
+    @Test
+    fun `accepted scrobble response is successful`() {
+        LastFM.validateLastFmResponse(
+            method = "track.scrobble",
+            responseText = """
+                {
+                  "scrobbles": {
+                    "scrobble": {
+                      "track": { "#text": "Test Track", "corrected": "0" },
+                      "artist": { "#text": "Test Artist", "corrected": "0" },
+                      "timestamp": "1287140447",
+                      "ignoredMessage": { "#text": "", "code": "0" }
+                    },
+                    "@attr": { "accepted": "1", "ignored": "0" }
+                  }
+                }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `ignored scrobble response fails with ignored code`() {
+        try {
+            LastFM.validateLastFmResponse(
+                method = "track.scrobble",
+                responseText = """
+                    {
+                      "scrobbles": {
+                        "scrobble": {
+                          "track": { "#text": "Test Track", "corrected": "0" },
+                          "artist": { "#text": "Unknown Artist", "corrected": "0" },
+                          "timestamp": "1288728940",
+                          "ignoredMessage": {
+                            "#text": "Artist name failed filter: Unknown Artist",
+                            "code": "1"
+                          }
+                        },
+                        "@attr": { "accepted": "0", "ignored": "1" }
+                      }
+                    }
+                """.trimIndent(),
+            )
+            fail("Expected LastFmIgnoredException")
+        } catch (e: LastFM.LastFmIgnoredException) {
+            assertEquals("track.scrobble", e.method)
+            assertEquals(1, e.ignoredCode)
+            assertEquals("Artist name failed filter: Unknown Artist", e.message)
+        }
+    }
+
+    @Test
+    fun `ignored now playing response fails with ignored code`() {
+        try {
+            LastFM.validateLastFmResponse(
+                method = "track.updateNowPlaying",
+                responseText = """
+                    {
+                      "nowplaying": {
+                        "track": { "#text": "Test Track", "corrected": "0" },
+                        "artist": { "#text": "Unknown Artist", "corrected": "0" },
+                        "ignoredMessage": {
+                          "#text": "Artist name failed filter: Unknown Artist",
+                          "code": "1"
+                        }
+                      }
+                    }
+                """.trimIndent(),
+            )
+            fail("Expected LastFmIgnoredException")
+        } catch (e: LastFM.LastFmIgnoredException) {
+            assertEquals("track.updateNowPlaying", e.method)
+            assertEquals(1, e.ignoredCode)
+            assertEquals("Artist name failed filter: Unknown Artist", e.message)
+        }
+    }
+
+    @Test
+    fun `api error response fails with LastFmException`() {
+        try {
+            LastFM.validateLastFmResponse(
+                method = "track.scrobble",
+                responseText = """{"error": 9, "message": "Invalid session key"}""",
+                statusCode = 403,
+            )
+            fail("Expected LastFmException")
+        } catch (e: LastFM.LastFmException) {
+            assertEquals(9, e.code)
+            assertEquals("Invalid session key", e.message)
+        }
+    }
+}

--- a/local.properties.sample
+++ b/local.properties.sample
@@ -1,0 +1,12 @@
+# Copy this file to local.properties and fill in only the values you need.
+# local.properties is ignored by Git and must never be committed with real secrets.
+
+# Required for Last.fm login/scrobbling in locally built APKs.
+# Create an API account at https://www.last.fm/api/account/create
+LASTFM_API_KEY=
+LASTFM_SECRET=
+
+# Optional: enables GitHub issue crash reporting for local builds.
+# Leave commented unless you have a token scoped to the target repository.
+# CRASH_REPORT_REPO=francescograzioso/Meld
+# CRASH_REPORT_TOKEN=


### PR DESCRIPTION
## Problem

Last.fm scrobbling could fail silently because ignored scrobble responses were not surfaced as failures. In some playback flows, eligible tracks could also miss their final scrobble when playback moved to the next track or ended.

## Cause

Last.fm can return a successful HTTP response while marking a scrobble or now playing update as ignored in the response payload. The app was not validating these ignored responses, so they were treated as successful.

The scrobble lifecycle also did not explicitly finalize eligible tracks on automatic transitions or playback end events.

## Solution

- Validate Last.fm responses for `track.scrobble` and `track.updateNowPlaying`.
- Add a dedicated `LastFmIgnoredException` for ignored Last.fm responses.
- Log ignored scrobbles and ignored now playing updates separately from regular request failures.
- Track the current song metadata, duration, start timestamp, and scrobble status in `ScrobbleManager`.
- Finalize eligible scrobbles on automatic track transitions and playback end.
- Prevent duplicate scrobbles for the same track.
- Show a clear login error when Last.fm API credentials are missing from the build.
- Add unit tests for accepted scrobbles, ignored scrobbles, ignored now playing responses, and API error responses.
- Add Docker support for a reproducible local development/build environment.

## Testing

- Ran the Last.fm response validation unit tests:

```bash
docker compose run --rm dev ./gradlew --console=plain :lastfm:testDebugUnitTest --tests com.metrolist.lastfm.LastFMResponseTest --warning-mode summary
```
## Related issue
Closes #201