### PR TITLE
fix(lastfm): surface ignored scrobbles and finalize playback scrobbling

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -933,14 +933,18 @@ class MusicService :
                     val minSongDuration =
                         dataStore.get(ScrobbleMinSongDurationKey, LastFM.DEFAULT_SCROBBLE_MIN_SONG_DURATION)
                     val delaySeconds = dataStore.get(ScrobbleDelaySecondsKey, LastFM.DEFAULT_SCROBBLE_DELAY_SECONDS)
-                    scrobbleManager =
+                    val manager =
                         ScrobbleManager(
                             scope,
                             minSongDuration = minSongDuration,
                             scrobbleDelayPercent = delayPercent,
                             scrobbleDelaySeconds = delaySeconds,
                         )
-                    scrobbleManager?.useNowPlaying = dataStore.get(LastFMUseNowPlaying, false)
+                    scrobbleManager = manager
+                    manager.useNowPlaying = dataStore.get(LastFMUseNowPlaying, false)
+                    if (::player.isInitialized && player.isPlaying) {
+                        manager.onSongStart(player.currentMetadata, duration = player.duration)
+                    }
                 } else if (!enabled && scrobbleManager != null) {
                     scrobbleManager?.destroy()
                     scrobbleManager = null
@@ -2204,7 +2208,7 @@ class MusicService :
         // Restart SponsorBlock for the new track (no-op when disabled).
         startSponsorBlockForCurrentTrack()
 
-        scrobbleManager?.onSongStop()
+        scrobbleManager?.onSongStop(finalize = reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO)
         if (player.playWhenReady && player.playbackState == Player.STATE_READY) {
             scrobbleManager?.onSongStart(player.currentMetadata, duration = player.duration)
         }
@@ -2292,7 +2296,9 @@ class MusicService :
             scheduleCrossfade()
         }
 
-        if (playbackState == Player.STATE_IDLE || playbackState == Player.STATE_ENDED) {
+        if (playbackState == Player.STATE_ENDED) {
+            scrobbleManager?.onSongStop(finalize = true)
+        } else if (playbackState == Player.STATE_IDLE) {
             scrobbleManager?.onSongStop()
         }
     }
@@ -2394,8 +2400,16 @@ class MusicService :
         }
 
         // Scrobbling
-        if (events.containsAny(Player.EVENT_IS_PLAYING_CHANGED)) {
-            scrobbleManager?.onPlayerStateChanged(player.isPlaying, player.currentMetadata, duration = player.duration)
+        if (events.containsAny(
+                Player.EVENT_IS_PLAYING_CHANGED,
+                Player.EVENT_PLAYBACK_STATE_CHANGED,
+            )
+        ) {
+            scrobbleManager?.onPlayerStateChanged(
+                player.isPlaying,
+                player.currentMetadata,
+                duration = player.duration,
+            )
         }
     }
 

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/integrations/LastFMSettings.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import androidx.navigation.NavController
 import com.metrolist.lastfm.LastFM
+import com.metrolist.music.BuildConfig
 import com.metrolist.music.LocalPlayerAwareWindowInsets
 import com.metrolist.music.R
 import com.metrolist.music.constants.EnableLastFMScrobblingKey
@@ -121,6 +122,7 @@ fun LastFMSettings(
     var showLoginDialog by rememberSaveable { mutableStateOf(false) }
     var isLoggingIn by rememberSaveable { mutableStateOf(false) }
     var loginError by rememberSaveable { mutableStateOf<String?>(null) }
+    val lastFmApiCredentialsMissingError = stringResource(R.string.lastfm_api_credentials_missing)
 
     if (showLoginDialog) {
         var tempUsername by rememberSaveable { mutableStateOf("") }
@@ -198,6 +200,10 @@ fun LastFMSettings(
                     onClick = {
                         if (tempUsername.isBlank() || tempPassword.isBlank()) {
                             loginError = "Please enter both username and password"
+                            return@TextButton
+                        }
+                        if (BuildConfig.LASTFM_API_KEY.isBlank() || BuildConfig.LASTFM_SECRET.isBlank()) {
+                            loginError = lastFmApiCredentialsMissingError
                             return@TextButton
                         }
 

--- a/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/ScrobbleManager.kt
@@ -20,29 +20,35 @@ class ScrobbleManager(
     var minSongDuration: Int = LastFM.DEFAULT_SCROBBLE_MIN_SONG_DURATION,
     var scrobbleDelayPercent: Float = LastFM.DEFAULT_SCROBBLE_DELAY_PERCENT,
     var scrobbleDelaySeconds: Int = LastFM.DEFAULT_SCROBBLE_DELAY_SECONDS,
+    private val client: LastFmScrobbleClient = LastFmScrobbleClient.Default,
 ) {
     private var scrobbleJob: Job? = null
     private var scrobbleRemainingMillis: Long = 0L
     private var scrobbleTimerStartedAt: Long = 0L
     private var songStartedAt: Long = 0L
     private var songStarted = false
+    private var currentMetadata: MediaMetadata? = null
+    private var currentSongDuration = 0
+    private var currentSongScrobbled = false
     var useNowPlaying = true
 
     fun destroy() {
         scrobbleJob?.cancel()
-        scrobbleRemainingMillis = 0L
-        scrobbleTimerStartedAt = 0L
-        songStartedAt = 0L
-        songStarted = false
+        resetCurrentSong()
     }
 
     fun onSongStart(metadata: MediaMetadata?, duration: Long? = null) {
         if (metadata == null) return
-        songStartedAt = System.currentTimeMillis() / 1000
+        val startedAt = System.currentTimeMillis() / 1000
+        val durationSeconds = resolveDuration(metadata, duration)
+        songStartedAt = startedAt
         songStarted = true
-        startScrobbleTimer(metadata, duration)
+        currentMetadata = metadata
+        currentSongDuration = durationSeconds
+        currentSongScrobbled = false
+        startScrobbleTimer(metadata, durationSeconds, startedAt)
         if (useNowPlaying) {
-            updateNowPlaying(metadata)
+            updateNowPlaying(metadata, durationSeconds)
         }
     }
 
@@ -54,32 +60,36 @@ class ScrobbleManager(
         pauseScrobbleTimer()
     }
 
-    fun onSongStop() {
+    fun onSongStop(finalize: Boolean = false) {
+        if (finalize || hasReachedScrobbleThreshold()) {
+            scrobbleCurrentSongIfNeeded()
+        }
         stopScrobbleTimer()
-        songStarted = false
+        resetCurrentSong()
     }
 
-    private fun startScrobbleTimer(metadata: MediaMetadata, duration: Long? = null) {
+    private fun startScrobbleTimer(
+        metadata: MediaMetadata,
+        duration: Int,
+        startedAt: Long = songStartedAt
+    ) {
         scrobbleJob?.cancel()
-        val duration = when {
-            duration == null || duration == C.TIME_UNSET || duration <= 0 -> metadata.duration
-            else -> (duration / 1000).toInt()
-        }
-
         if (duration <= minSongDuration) return
 
         val threshold = duration * 1000L * scrobbleDelayPercent
         scrobbleRemainingMillis = min(threshold.toLong(), scrobbleDelaySeconds * 1000L)
 
         if (scrobbleRemainingMillis <= 0) {
-            scrobbleSong(metadata)
+            scrobbleSongIfNeeded(metadata, startedAt, duration)
             return
         }
         scrobbleTimerStartedAt = System.currentTimeMillis()
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
-            scrobbleSong(metadata)
+            scrobbleSongIfNeeded(metadata, startedAt, duration)
             scrobbleJob = null
+            scrobbleRemainingMillis = 0L
+            scrobbleTimerStartedAt = 0L
         }
     }
 
@@ -100,8 +110,10 @@ class ScrobbleManager(
         scrobbleTimerStartedAt = System.currentTimeMillis()
         scrobbleJob = scope.launch {
             delay(scrobbleRemainingMillis)
-            scrobbleSong(metadata)
+            scrobbleSongIfNeeded(metadata, songStartedAt, currentSongDuration)
             scrobbleJob = null
+            scrobbleRemainingMillis = 0L
+            scrobbleTimerStartedAt = 0L
         }
     }
 
@@ -111,32 +123,94 @@ class ScrobbleManager(
         scrobbleRemainingMillis = 0
     }
 
-    private fun scrobbleSong(metadata: MediaMetadata) {
+    private fun hasReachedScrobbleThreshold(): Boolean {
+        if (currentSongDuration <= minSongDuration || currentSongScrobbled) return false
+        return remainingScrobbleMillis() <= 0L
+    }
+
+    private fun remainingScrobbleMillis(): Long =
+        if (scrobbleTimerStartedAt == 0L) {
+            scrobbleRemainingMillis
+        } else {
+            scrobbleRemainingMillis - (System.currentTimeMillis() - scrobbleTimerStartedAt)
+        }
+
+    private fun scrobbleCurrentSongIfNeeded() {
+        val metadata = currentMetadata ?: return
+        if (currentSongDuration <= minSongDuration) return
+        scrobbleSongIfNeeded(metadata, songStartedAt, currentSongDuration)
+    }
+
+    private fun scrobbleSongIfNeeded(
+        metadata: MediaMetadata,
+        startedAt: Long,
+        duration: Int,
+    ) {
+        if (currentSongScrobbled || startedAt <= 0L) return
+        currentSongScrobbled = true
+        scrobbleSong(metadata, startedAt, duration)
+    }
+
+    private fun scrobbleSong(
+        metadata: MediaMetadata,
+        startedAt: Long,
+        duration: Int,
+    ) {
         scope.launch {
             val artist = metadata.artists.joinToString { it.name }
-            LastFM.scrobble(
+            client.scrobble(
                 artist = artist,
                 track = metadata.title,
-                duration = metadata.duration,
-                timestamp = songStartedAt,
+                duration = duration.takeIf { it > 0 },
+                timestamp = startedAt,
                 album = metadata.album?.title,
             ).onSuccess {
                 Timber.d("Last.fm: scrobbled \"${metadata.title}\" by $artist")
             }.onFailure { e ->
-                Timber.w(e, "Last.fm: scrobble failed for \"${metadata.title}\" by $artist")
+                if (e is LastFM.LastFmIgnoredException) {
+                    Timber.w(
+                        "Last.fm: scrobble ignored for \"${metadata.title}\" by $artist " +
+                            "(code ${e.ignoredCode}): ${e.message}"
+                    )
+                } else {
+                    Timber.w(e, "Last.fm: scrobble failed for \"${metadata.title}\" by $artist")
+                }
             }
         }
     }
 
-    private fun updateNowPlaying(metadata: MediaMetadata) {
+    private fun resolveDuration(metadata: MediaMetadata, duration: Long? = null): Int =
+        when {
+            duration == null || duration == C.TIME_UNSET || duration <= 0 -> metadata.duration
+            else -> (duration / 1000).toInt()
+        }
+
+    private fun resetCurrentSong() {
+        scrobbleRemainingMillis = 0L
+        scrobbleTimerStartedAt = 0L
+        songStartedAt = 0L
+        songStarted = false
+        currentMetadata = null
+        currentSongDuration = 0
+        currentSongScrobbled = false
+    }
+
+    private fun updateNowPlaying(metadata: MediaMetadata, duration: Int) {
         scope.launch {
-            LastFM.updateNowPlaying(
+            client.updateNowPlaying(
                 artist = metadata.artists.joinToString { it.name },
                 track = metadata.title,
                 album = metadata.album?.title,
-                duration = metadata.duration,
+                duration = duration.takeIf { it > 0 },
             ).onFailure { e ->
-                Timber.w(e, "Last.fm: updateNowPlaying failed for \"${metadata.title}\"")
+                if (e is LastFM.LastFmIgnoredException) {
+                    Timber.w(
+                        "Last.fm: updateNowPlaying ignored for \"${metadata.title}\" " +
+                            "(code ${e.ignoredCode}): ${e.message}"
+                    )
+                } else {
+                    Timber.w(e, "Last.fm: updateNowPlaying failed for \"${metadata.title}\"")
+                }
             }
         }
     }
@@ -144,7 +218,10 @@ class ScrobbleManager(
     fun onPlayerStateChanged(isPlaying: Boolean, metadata: MediaMetadata?, duration: Long? = null) {
         if (metadata == null) return
         if (isPlaying) {
-            if (!songStarted) {
+            if (!songStarted || currentMetadata?.id != metadata.id) {
+                if (songStarted) {
+                    onSongStop()
+                }
                 onSongStart(metadata, duration)
             } else {
                 onSongResume(metadata)
@@ -152,5 +229,52 @@ class ScrobbleManager(
         } else {
             onSongPause()
         }
+    }
+}
+
+interface LastFmScrobbleClient {
+    suspend fun updateNowPlaying(
+        artist: String,
+        track: String,
+        album: String? = null,
+        duration: Int? = null,
+    ): Result<Unit>
+
+    suspend fun scrobble(
+        artist: String,
+        track: String,
+        timestamp: Long,
+        album: String? = null,
+        duration: Int? = null,
+    ): Result<Unit>
+
+    object Default : LastFmScrobbleClient {
+        override suspend fun updateNowPlaying(
+            artist: String,
+            track: String,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> =
+            LastFM.updateNowPlaying(
+                artist = artist,
+                track = track,
+                album = album,
+                duration = duration,
+            )
+
+        override suspend fun scrobble(
+            artist: String,
+            track: String,
+            timestamp: Long,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> =
+            LastFM.scrobble(
+                artist = artist,
+                track = track,
+                duration = duration,
+                timestamp = timestamp,
+                album = album,
+            )
     }
 }

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -410,6 +410,7 @@
     <string name="lastfm_integration">Last.fm integration</string>
     <string name="enable_scrobbling">Enable scrobbling</string>
     <string name="lastfm_now_playing">Send Now Playing status</string>
+    <string name="lastfm_api_credentials_missing">Last.fm API credentials are missing from this build.</string>
     <string name="last_fm_send_likes">Sync Loved and Unloved</string>
     <string name="last_fm_send_likes_description">Love or unlove songs in Last.fm when you like or unlike them in Meld</string>
     <string name="logging_in">Logging in…</string>

--- a/app/src/test/kotlin/com/metrolist/music/utils/ScrobbleManagerTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/ScrobbleManagerTest.kt
@@ -1,0 +1,108 @@
+package com.metrolist.music.utils
+
+import com.metrolist.music.models.MediaMetadata
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScrobbleManagerTest {
+
+    @Test
+    fun `transition followed by playing state change scrobbles each song once`() = runBlocking {
+        val client = FakeLastFmScrobbleClient()
+        val manager = ScrobbleManager(
+            scope = this,
+            minSongDuration = 1,
+            scrobbleDelayPercent = 0.02f,
+            scrobbleDelaySeconds = 10,
+            client = client,
+        )
+        val firstSong = mediaMetadata(id = "first", title = "First")
+        val secondSong = mediaMetadata(id = "second", title = "Second")
+
+        manager.onSongStart(firstSong, duration = 10_000L)
+        manager.onSongStop(finalize = true)
+        manager.onSongStart(secondSong, duration = 10_000L)
+        manager.onPlayerStateChanged(isPlaying = true, metadata = secondSong, duration = 10_000L)
+        delay(300)
+
+        assertEquals(
+            listOf(
+                FakeScrobble(track = "First", duration = 10),
+                FakeScrobble(track = "Second", duration = 10),
+            ),
+            client.scrobbles,
+        )
+
+        manager.destroy()
+    }
+
+    @Test
+    fun `playing metadata change restarts scrobble timer for the new song`() = runBlocking {
+        val client = FakeLastFmScrobbleClient()
+        val manager = ScrobbleManager(
+            scope = this,
+            minSongDuration = 1,
+            scrobbleDelayPercent = 0.02f,
+            scrobbleDelaySeconds = 10,
+            client = client,
+        )
+
+        manager.onPlayerStateChanged(
+            isPlaying = true,
+            metadata = mediaMetadata(id = "first", title = "First"),
+            duration = 10_000L,
+        )
+        delay(50)
+
+        manager.onPlayerStateChanged(
+            isPlaying = true,
+            metadata = mediaMetadata(id = "second", title = "Second", duration = -1),
+            duration = 10_000L,
+        )
+        delay(300)
+
+        assertEquals(listOf(FakeScrobble(track = "Second", duration = 10)), client.scrobbles)
+
+        manager.destroy()
+    }
+
+    private fun mediaMetadata(
+        id: String,
+        title: String,
+        duration: Int = 10,
+    ) = MediaMetadata(
+        id = id,
+        title = title,
+        artists = listOf(MediaMetadata.Artist(id = null, name = "Artist")),
+        duration = duration,
+    )
+
+    private class FakeLastFmScrobbleClient : LastFmScrobbleClient {
+        val scrobbles = mutableListOf<FakeScrobble>()
+
+        override suspend fun updateNowPlaying(
+            artist: String,
+            track: String,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> = Result.success(Unit)
+
+        override suspend fun scrobble(
+            artist: String,
+            track: String,
+            timestamp: Long,
+            album: String?,
+            duration: Int?,
+        ): Result<Unit> {
+            scrobbles += FakeScrobble(track = track, duration = duration)
+            return Result.success(Unit)
+        }
+    }
+
+    private data class FakeScrobble(
+        val track: String,
+        val duration: Int?,
+    )
+}

--- a/lastfm/src/main/kotlin/com/metrolist/lastfm/LastFM.kt
+++ b/lastfm/src/main/kotlin/com/metrolist/lastfm/LastFM.kt
@@ -14,6 +14,12 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 import java.security.MessageDigest
 
 object LastFM {
@@ -116,11 +122,20 @@ object LastFM {
         override fun toString(): String = "LastFmException(code=$code, message=$message)"
     }
 
+    class LastFmIgnoredException(
+        val method: String,
+        val ignoredCode: Int,
+        override val message: String
+    ) : Exception(message) {
+        override fun toString(): String =
+            "LastFmIgnoredException(method=$method, ignoredCode=$ignoredCode, message=$message)"
+    }
+
     suspend fun updateNowPlaying(
         artist: String, track: String,
         album: String? = null, trackNumber: Int? = null, duration: Int? = null
     ) = runCatching {
-        client.post {
+        val response = client.post {
             lastfmParams(
                 method = "track.updateNowPlaying",
                 apiKey = API_KEY,
@@ -136,13 +151,18 @@ object LastFM {
             )
             parameter("format", "json")
         }
+        validateLastFmResponse(
+            method = "track.updateNowPlaying",
+            responseText = response.bodyAsText(),
+            statusCode = response.status.value,
+        )
     }
 
     suspend fun scrobble(
         artist: String, track: String, timestamp: Long,
         album: String? = null, trackNumber: Int? = null, duration: Int? = null
     ) = runCatching {
-        client.post {
+        val response = client.post {
             lastfmParams(
                 method = "track.scrobble",
                 apiKey = API_KEY,
@@ -159,6 +179,11 @@ object LastFM {
             )
             parameter("format", "json")
         }
+        validateLastFmResponse(
+            method = "track.scrobble",
+            responseText = response.bodyAsText(),
+            statusCode = response.status.value,
+        )
     }
 
     suspend fun setLoveStatus(
@@ -195,6 +220,95 @@ object LastFM {
     }
 
     fun isInitialized(): Boolean = API_KEY.isNotEmpty() && SECRET.isNotEmpty()
+
+    internal fun validateLastFmResponse(
+        method: String,
+        responseText: String,
+        statusCode: Int = 200
+    ) {
+        val root = runCatching { json.parseToJsonElement(responseText).jsonObject }
+            .getOrElse {
+                if (statusCode !in 200..299) {
+                    throw LastFmException(statusCode, "Last.fm $method failed with HTTP $statusCode")
+                }
+                throw LastFmException(-1, "Last.fm $method returned an invalid response")
+            }
+
+        root.intValue("error")?.let { code ->
+            throw LastFmException(code, root.stringValue("message") ?: "Last.fm $method failed")
+        }
+
+        if (statusCode !in 200..299) {
+            throw LastFmException(statusCode, "Last.fm $method failed with HTTP $statusCode")
+        }
+
+        when (method) {
+            "track.scrobble" -> {
+                val scrobbles = root["scrobbles"]?.jsonObjectOrNull()
+                    ?: throw LastFmException(-1, "Last.fm $method returned an invalid response")
+                validateScrobbleResult(scrobbles)
+            }
+
+            "track.updateNowPlaying" -> {
+                val nowPlaying = root["nowplaying"]?.jsonObjectOrNull()
+                    ?: throw LastFmException(-1, "Last.fm $method returned an invalid response")
+                nowPlaying.findIgnoredMessage()?.throwIfIgnored(method)
+            }
+        }
+    }
+
+    private fun validateScrobbleResult(scrobbles: JsonObject) {
+        val ignoredCount = scrobbles["@attr"]
+            ?.jsonObjectOrNull()
+            ?.intValue("ignored")
+            ?: 0
+
+        val ignoredMessage = scrobbles["scrobble"]
+            ?.asIterable()
+            ?.mapNotNull { it.jsonObjectOrNull()?.findIgnoredMessage() }
+            ?.firstOrNull { it.code != 0 }
+
+        if (ignoredCount > 0) {
+            (ignoredMessage ?: IgnoredMessage(code = -1, message = "Last.fm ignored the scrobble"))
+                .throwIfIgnored("track.scrobble")
+        }
+    }
+
+    private fun JsonObject.findIgnoredMessage(): IgnoredMessage? {
+        val ignoredMessage = this["ignoredMessage"]?.jsonObjectOrNull()
+            ?: this["ignoredmessage"]?.jsonObjectOrNull()
+            ?: return null
+
+        return IgnoredMessage(
+            code = ignoredMessage.intValue("code") ?: 0,
+            message = ignoredMessage.stringValue("#text")
+                ?: ignoredMessage.stringValue("text")
+                ?: ignoredMessage.stringValue("message")
+                ?: "Last.fm ignored the request"
+        )
+    }
+
+    private fun IgnoredMessage.throwIfIgnored(method: String) {
+        if (code == 0) return
+        throw LastFmIgnoredException(method, code, message.ifBlank { "Last.fm ignored the request" })
+    }
+
+    private fun JsonElement.asIterable(): List<JsonElement> =
+        runCatching { jsonArray.toList() }.getOrElse { listOf(this) }
+
+    private fun JsonElement.jsonObjectOrNull(): JsonObject? =
+        runCatching { jsonObject }.getOrNull()
+
+    private fun JsonObject.stringValue(key: String): String? =
+        (this[key] as? JsonPrimitive)?.contentOrNull
+
+    private fun JsonObject.intValue(key: String): Int? =
+        stringValue(key)?.toIntOrNull()
+
+    private data class IgnoredMessage(
+        val code: Int,
+        val message: String
+    )
 
     const val DEFAULT_SCROBBLE_DELAY_PERCENT = 0.5f
     const val DEFAULT_SCROBBLE_MIN_SONG_DURATION = 30

--- a/lastfm/src/test/kotlin/com/metrolist/lastfm/LastFMResponseTest.kt
+++ b/lastfm/src/test/kotlin/com/metrolist/lastfm/LastFMResponseTest.kt
@@ -1,0 +1,99 @@
+package com.metrolist.lastfm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class LastFMResponseTest {
+
+    @Test
+    fun `accepted scrobble response is successful`() {
+        LastFM.validateLastFmResponse(
+            method = "track.scrobble",
+            responseText = """
+                {
+                  "scrobbles": {
+                    "scrobble": {
+                      "track": { "#text": "Test Track", "corrected": "0" },
+                      "artist": { "#text": "Test Artist", "corrected": "0" },
+                      "timestamp": "1287140447",
+                      "ignoredMessage": { "#text": "", "code": "0" }
+                    },
+                    "@attr": { "accepted": "1", "ignored": "0" }
+                  }
+                }
+            """.trimIndent(),
+        )
+    }
+
+    @Test
+    fun `ignored scrobble response fails with ignored code`() {
+        try {
+            LastFM.validateLastFmResponse(
+                method = "track.scrobble",
+                responseText = """
+                    {
+                      "scrobbles": {
+                        "scrobble": {
+                          "track": { "#text": "Test Track", "corrected": "0" },
+                          "artist": { "#text": "Unknown Artist", "corrected": "0" },
+                          "timestamp": "1288728940",
+                          "ignoredMessage": {
+                            "#text": "Artist name failed filter: Unknown Artist",
+                            "code": "1"
+                          }
+                        },
+                        "@attr": { "accepted": "0", "ignored": "1" }
+                      }
+                    }
+                """.trimIndent(),
+            )
+            fail("Expected LastFmIgnoredException")
+        } catch (e: LastFM.LastFmIgnoredException) {
+            assertEquals("track.scrobble", e.method)
+            assertEquals(1, e.ignoredCode)
+            assertEquals("Artist name failed filter: Unknown Artist", e.message)
+        }
+    }
+
+    @Test
+    fun `ignored now playing response fails with ignored code`() {
+        try {
+            LastFM.validateLastFmResponse(
+                method = "track.updateNowPlaying",
+                responseText = """
+                    {
+                      "nowplaying": {
+                        "track": { "#text": "Test Track", "corrected": "0" },
+                        "artist": { "#text": "Unknown Artist", "corrected": "0" },
+                        "ignoredMessage": {
+                          "#text": "Artist name failed filter: Unknown Artist",
+                          "code": "1"
+                        }
+                      }
+                    }
+                """.trimIndent(),
+            )
+            fail("Expected LastFmIgnoredException")
+        } catch (e: LastFM.LastFmIgnoredException) {
+            assertEquals("track.updateNowPlaying", e.method)
+            assertEquals(1, e.ignoredCode)
+            assertEquals("Artist name failed filter: Unknown Artist", e.message)
+        }
+    }
+
+    @Test
+    fun `api error response fails with LastFmException`() {
+        try {
+            LastFM.validateLastFmResponse(
+                method = "track.scrobble",
+                responseText = """{"error": 9, "message": "Invalid session key"}""",
+                statusCode = 403,
+            )
+            fail("Expected LastFmException")
+        } catch (e: LastFM.LastFmException) {
+            assertEquals(9, e.code)
+            assertEquals("Invalid session key", e.message)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Last.fm can return HTTP 200 while rejecting a scrobble or now-playing request in the response payload. These ignored requests were not surfaced correctly.

Playback transitions could also trigger overlapping scrobbling paths through both `onMediaItemTransition` and `onEvents`.

## Cause

The Last.fm client treated ignored payload responses as successful requests. The playback callbacks independently handled the same media transition, making the lifecycle fragile.

## Solution

- Add `LastFmIgnoredException` for ignored Last.fm responses.
- Log ignored scrobbles and now-playing requests separately from request failures.
- Prevent duplicate scrobbles with `currentSongScrobbled`.
- Finalize eligible scrobbles on automatic transitions and playback end.
- Handle media transitions through a single scrobbling path.
- Inject `LastFmScrobbleClient` into `ScrobbleManager`.
- Add unit coverage for ignored responses and the transition-to-start sequence.

## Testing

- Added `LastFMResponseTest`.
- Added `ScrobbleManagerTest`.
- Covered HTTP 200 ignored responses.
- Covered transition followed by a playing state update.
- `git diff --cached --check` passes.

## Related Issues

- Closes #201
- Related to #216