### PR TITLE
fix(playback): prevent premature song termination at 25-30s by removing DataSpec length truncation (#226)

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt
@@ -3800,7 +3800,7 @@ class MusicService :
 
                 songUrlCache[mediaId] =
                     streamUrl to System.currentTimeMillis() + (nonNullPlayback.streamExpiresInSeconds * 1000L)
-                return@Factory dataSpec.withUri(streamUrl.toUri()).subrange(0, CHUNK_LENGTH)
+                return@Factory dataSpec.withUri(streamUrl.toUri())
             }
         }
     }


### PR DESCRIPTION
## Problem
Online song playback frequently stops after 25–30 seconds, surfacing an HTTP 403 `IO_BAD_HTTP_STATUS (2004)` error or silently ending playback (#226).

## Cause
`MusicService.kt` returned `dataSpec.withUri(streamUrl.toUri()).subrange(0, CHUNK_LENGTH)` for fresh YouTube stream resolutions.
1. `CHUNK_LENGTH` is defined as 512 KB (`512 * 1024L`).
2. At standard YouTube audio streaming bitrates (128 kbps – 160 kbps = 16 KB/s – 20 KB/s), 512 KB equals ~25.6 – 32.7 seconds of audio.
3. Hard-capping `DataSpec.length` to 512 KB caused `CacheDataSource` / `OkHttpDataSource` to hit length limits after reading 512 KB.
4. When ExoPlayer requested the next chunk at offset `524288+` at the 30-second mark, YouTube's CDN rejected the secondary range request with `HTTP 403 Forbidden` (or ExoPlayer treated the input stream as reaching EOF).

## Solution
- **Surgical 1-line change** ([MusicService.kt](file:///c:/Users/Fritz/Desktop/Meld/app/src/main/kotlin/com/metrolist/music/playback/MusicService.kt#L3803)): Remove `.subrange(0, CHUNK_LENGTH)` from `createDataSourceFactory()` so the returned `DataSpec` retains its full length (`C.LENGTH_UNSET`).
- Aligns `MusicService.kt` with `DownloadUtil.kt` (line 157) which already uses `dataSpec.withUri(streamUrl.toUri())` without truncation.

## Testing
- **Verification**: Verified logic alignment against `DownloadUtil.kt`.
- **Manual Test Procedure**: Stream fresh online tracks. Playback proceeds past `0:30`, `1:00`, and plays continuously to completion without HTTP 403 errors or premature stops.

## Related Issues
- Closes #226