### PR TITLE
fix(playlist): limit proactive Mix loading and add infinite scroll

### DIFF
--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/playlist/OnlinePlaylistScreen.kt
@@ -186,6 +186,15 @@ fun OnlinePlaylistScreen(
         BackHandler(onBack = onExitSelectionMode)
     }
 
+    LaunchedEffect(lazyListState) {
+        androidx.compose.runtime.snapshotFlow { lazyListState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+            .collect { lastVisibleIndex ->
+                if (lastVisibleIndex != null && lastVisibleIndex >= songs.size - 5 && !isLoadingMore && viewModel.continuation != null) {
+                    viewModel.loadMoreSongs()
+                }
+            }
+    }
+
     Box(Modifier.fillMaxSize()) {
         LazyColumn(
             state = lazyListState,

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
@@ -208,12 +208,19 @@ class OnlinePlaylistViewModel @Inject constructor(
         proactiveLoadJob?.cancel() // Cancel previous job if any
         proactiveLoadJob = viewModelScope.launch(Dispatchers.IO) {
             var currentProactiveToken = continuation
+            val isMix = playlistId.removePrefix("VL").startsWith("RD")
+
             while (currentProactiveToken != null && isActive) {
                 // If a manual loadMore is happening, pause proactive loading
                 if (_isLoadingMore.value) {
                     // Wait until manual load is finished, then re-evaluate
                     // This simple break and restart strategy from loadMoreSongs is preferred
                     break 
+                }
+
+                // Limit proactive loading for Mixes to avoid infinite loops and high memory usage
+                if (isMix && playlistSongs.value.size >= 500) {
+                    break
                 }
 
                 YouTube.playlistContinuation(currentProactiveToken)

--- a/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
+++ b/app/src/main/kotlin/com/metrolist/music/viewmodels/OnlinePlaylistViewModel.kt
@@ -150,7 +150,7 @@ class OnlinePlaylistViewModel @Inject constructor(
                 playlistSongs.value = applySongFilters(playlistPage.songs)
                 continuation = playlistPage.songsContinuation
                 _isLoading.value = false
-                if (continuation != null) {
+                if (continuation != null && !playlistId.removePrefix("VL").startsWith("RD")) {
                     startProactiveBackgroundLoading()
                 }
             }.onFailure { throwable ->
@@ -260,7 +260,7 @@ class OnlinePlaylistViewModel @Inject constructor(
                 }.also {
                     _isLoadingMore.value = false
                     // Resume proactive loading if there's still a continuation
-                    if (continuation != null && isActive) {
+                    if (continuation != null && isActive && !playlistId.removePrefix("VL").startsWith("RD")) {
                         startProactiveBackgroundLoading()
                     }
                 }


### PR DESCRIPTION
## Problem
YouTube Music Mixes (IDs starting with RD) would automatically load thousands of songs immediately after opening, causing UI lag and jumping song counts.

## Cause
OnlinePlaylistViewModel was proactive fetching all continuations in a loop. Since Mixes are virtually infinite, it never stopped loading.

## Solution
- Disabled proactive loading for Mixes: The app now only loads the initial ~100 songs on open.
- Manual Infinite Scroll: Added a scroll listener to OnlinePlaylistScreen so new songs are only fetched when the user actually reaches the bottom of the list.

## Testing
- Confirmed Mix counts stay stable at 100 on open.
- Verified more songs load only when scrolling to the end.
- Verified ./gradlew :app:assembleFossDebug passes.
