### PR TITLE
fix(updater): download and install updates in app instead of opening a browser

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <!-- Microphone feature for music recognition (not required) -->
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
@@ -254,6 +255,11 @@
         <!-- Receiver for Listen Together notification actions (Approve/Reject) -->
         <receiver
             android:name=".listentogether.ListenTogetherActionReceiver"
+            android:exported="false" />
+
+        <!-- Receiver for package installer status during in-app updates -->
+        <receiver
+            android:name=".utils.UpdateInstallReceiver"
             android:exported="false" />
 
         <receiver

--- a/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
+++ b/app/src/main/kotlin/com/metrolist/music/MainActivity.kt
@@ -221,6 +221,7 @@ class MainActivity : ComponentActivity() {
         private const val ACTION_SEARCH = "com.metrolist.music.action.SEARCH"
         private const val ACTION_LIBRARY = "com.metrolist.music.action.LIBRARY"
         const val ACTION_RECOGNITION = "com.metrolist.music.action.RECOGNITION"
+        const val ACTION_UPDATE = "com.metrolist.music.action.UPDATE"
         const val EXTRA_AUTO_START_RECOGNITION = "auto_start_recognition"
     }
 
@@ -440,7 +441,9 @@ class MainActivity : ComponentActivity() {
                                 if (hasUpdate && notifEnabled) {
                                     val downloadUrl = Updater.getDownloadUrlForCurrentVariant(releaseInfo)
                                     if (downloadUrl != null) {
-                                        val intent = Intent(Intent.ACTION_VIEW, downloadUrl.toUri())
+                                        val intent =
+                                            Intent(this@MainActivity, MainActivity::class.java)
+                                                .setAction(ACTION_UPDATE)
 
                                         val flags =
                                             PendingIntent.FLAG_UPDATE_CURRENT or
@@ -863,10 +866,12 @@ class MainActivity : ComponentActivity() {
                 LaunchedEffect(Unit) {
                     if (pendingIntent != null) {
                         handleRecognitionIntent(pendingIntent!!, navController)
+                        handleUpdateIntent(pendingIntent!!, navController)
                         handleDeepLinkIntent(pendingIntent!!, navController)
                         pendingIntent = null
                     } else {
                         handleRecognitionIntent(intent, navController)
+                        handleUpdateIntent(intent, navController)
                         handleDeepLinkIntent(intent, navController)
                     }
                 }
@@ -875,6 +880,7 @@ class MainActivity : ComponentActivity() {
                     val listener =
                         Consumer<Intent> { intent ->
                             handleRecognitionIntent(intent, navController)
+                            handleUpdateIntent(intent, navController)
                             handleDeepLinkIntent(intent, navController)
                         }
 
@@ -1350,6 +1356,21 @@ class MainActivity : ComponentActivity() {
         intent.action = null
         intent.removeExtra(EXTRA_AUTO_START_RECOGNITION)
         navController.navigate(if (autoStart) "recognition?autoStart=true" else "recognition") {
+            launchSingleTop = true
+        }
+    }
+
+    /**
+     * Handles the ACTION_UPDATE intent sent from the update notification.
+     * Opens the updater screen so the update is downloaded and installed in app.
+     */
+    private fun handleUpdateIntent(
+        intent: Intent,
+        navController: NavHostController,
+    ) {
+        if (intent.action != ACTION_UPDATE) return
+        intent.action = null
+        navController.navigate("settings/updater") {
             launchSingleTop = true
         }
     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/AccountSettings.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -82,7 +81,6 @@ fun AccountSettings(
     latestVersionName: String
 ) {
     val context = LocalContext.current
-    val uriHandler = LocalUriHandler.current
 
     val (accountNamePref, onAccountNameChange) = rememberPreference(AccountNameKey, "")
     val (accountEmail, onAccountEmailChange) = rememberPreference(AccountEmailKey, "")
@@ -426,7 +424,8 @@ fun AccountSettings(
                             }
                         },
                         onClick = {
-                            uriHandler.openUri(downloadUrl)
+                            onClose()
+                            navController.navigate("settings/updater")
                         }
                     )
                 }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/SettingsScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -46,7 +45,6 @@ fun SettingsScreen(
     navController: NavController,
     latestVersionName: String,
 ) {
-    val uriHandler = LocalUriHandler.current
     val context = LocalContext.current
     val isAndroid12OrLater = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
     val hasAndroidAuto = remember {
@@ -254,7 +252,7 @@ fun SettingsScreen(
                                     )
                                 },
                                 showBadge = true,
-                                onClick = { uriHandler.openUri(downloadUrl) }
+                                onClick = { navController.navigate("settings/updater") }
                             )
                         )
                     }

--- a/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/UpdaterSettings.kt
+++ b/app/src/main/kotlin/com/metrolist/music/ui/screens/settings/UpdaterSettings.kt
@@ -19,11 +19,14 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,6 +34,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,6 +49,9 @@ import com.metrolist.music.ui.component.IconButton
 import com.metrolist.music.ui.component.Material3SettingsGroup
 import com.metrolist.music.ui.component.Material3SettingsItem
 import com.metrolist.music.ui.utils.backToMain
+import com.metrolist.music.utils.UpdateInstallFailure
+import com.metrolist.music.utils.UpdateInstallState
+import com.metrolist.music.utils.UpdateInstaller
 import com.metrolist.music.utils.Updater
 import com.metrolist.music.utils.rememberPreference
 import kotlinx.coroutines.Dispatchers
@@ -66,22 +73,25 @@ fun UpdaterScreen(
     var showChangelog by remember { mutableStateOf(false) }
     var changelogContent by remember { mutableStateOf<String?>(null) }
     var checkError by remember { mutableStateOf<String?>(null) }
+    var downloadUrl by remember { mutableStateOf<String?>(null) }
     val failedToCheckUpdatesTemplate = stringResource(R.string.failed_to_check_updates)
+    val installState by UpdateInstaller.state.collectAsState()
 
     val coroutineScope = rememberCoroutineScope()
 
-    fun performManualCheck() {
+    fun performCheck(forceRefresh: Boolean) {
         coroutineScope.launch {
             isChecking = true
             checkError = null
             withContext(Dispatchers.IO) {
                 Updater
-                    .checkForUpdate(forceRefresh = true)
+                    .checkForUpdate(forceRefresh = forceRefresh)
                     .onSuccess { (releaseInfo, hasUpdate) ->
                         if (releaseInfo != null) {
                             latestVersion = releaseInfo.versionName
                             updateAvailable = hasUpdate
                             changelogContent = releaseInfo.description
+                            downloadUrl = Updater.getDownloadUrlForCurrentVariant(releaseInfo)
                         }
                     }.onFailure {
                         checkError = String.format(failedToCheckUpdatesTemplate, it.message ?: "Unknown error")
@@ -89,6 +99,11 @@ fun UpdaterScreen(
             }
             isChecking = false
         }
+    }
+
+    // Reuses the cached result so arriving from the update notification shows the action right away
+    LaunchedEffect(Unit) {
+        if (checkForUpdates) performCheck(forceRefresh = false)
     }
 
     Column(
@@ -199,7 +214,7 @@ fun UpdaterScreen(
                                 )
                             }
                         },
-                        onClick = { if (!isChecking) performManualCheck() },
+                        onClick = { if (!isChecking) performCheck(forceRefresh = true) },
                     ),
                 ),
         )
@@ -216,6 +231,90 @@ fun UpdaterScreen(
 
         if (updateAvailable && latestVersion != null) {
             Spacer(Modifier.height(16.dp))
+
+            when (val state = installState) {
+                is UpdateInstallState.Downloading -> {
+                    Text(
+                        text = stringResource(R.string.downloading_update, (state.progress * 100).toInt()),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    LinearProgressIndicator(
+                        progress = { state.progress },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                        strokeCap = StrokeCap.Round,
+                    )
+                }
+
+                UpdateInstallState.Installing -> {
+                    Text(
+                        text = stringResource(R.string.installing_update),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    LinearProgressIndicator(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                        strokeCap = StrokeCap.Round,
+                    )
+                }
+
+                else -> {
+                    Button(
+                        onClick = { downloadUrl?.let { UpdateInstaller.start(context, it) } },
+                        enabled = downloadUrl != null,
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                    ) {
+                        Text(stringResource(R.string.download_and_install))
+                    }
+                }
+            }
+
+            if (installState == UpdateInstallState.AwaitingConfirmation) {
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.awaiting_install_confirmation),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+            }
+
+            (installState as? UpdateInstallState.Failed)?.let { failure ->
+                Spacer(Modifier.height(12.dp))
+                Text(
+                    text = stringResource(failure.reason.messageRes()),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                )
+
+                if (failure.reason == UpdateInstallFailure.PermissionRequired) {
+                    Spacer(Modifier.height(8.dp))
+                    Button(
+                        onClick = {
+                            UpdateInstaller.reset()
+                            context.startActivity(UpdateInstaller.unknownSourcesSettingsIntent(context))
+                        },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                    ) {
+                        Text(stringResource(R.string.grant_permission))
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(12.dp))
             Button(
                 onClick = { showChangelog = !showChangelog },
                 modifier =
@@ -257,3 +356,10 @@ fun UpdaterScreen(
         },
     )
 }
+
+private fun UpdateInstallFailure.messageRes(): Int =
+    when (this) {
+        UpdateInstallFailure.PermissionRequired -> R.string.update_install_permission_required
+        UpdateInstallFailure.Download -> R.string.update_download_failed
+        UpdateInstallFailure.Install -> R.string.update_install_failed
+    }

--- a/app/src/main/kotlin/com/metrolist/music/utils/UpdateInstallReceiver.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/UpdateInstallReceiver.kt
@@ -1,0 +1,128 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import android.Manifest
+import android.app.ActivityManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Process
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.metrolist.music.R
+
+/**
+ * Receives install session status from the system package installer.
+ */
+class UpdateInstallReceiver : BroadcastReceiver() {
+    companion object {
+        const val ACTION_INSTALL_STATUS = "com.metrolist.music.action.INSTALL_STATUS"
+
+        private const val UPDATES_CHANNEL_ID = "updates"
+        private const val CONFIRM_NOTIFICATION_ID = 1002
+        private const val CONFIRM_REQUEST_CODE = 1002
+
+        /** Drops a confirmation prompt left over from an install that never finished. */
+        internal fun clearConfirmation(context: Context) {
+            NotificationManagerCompat.from(context).cancel(CONFIRM_NOTIFICATION_ID)
+        }
+    }
+
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (intent.action != ACTION_INSTALL_STATUS) return
+
+        when (intent.getIntExtra(PackageInstaller.EXTRA_STATUS, PackageInstaller.STATUS_FAILURE)) {
+            PackageInstaller.STATUS_PENDING_USER_ACTION -> requestConfirmation(context, intent)
+
+            PackageInstaller.STATUS_SUCCESS -> {
+                clearConfirmation(context)
+                UpdateInstaller.onInstallSucceeded(context)
+            }
+
+            PackageInstaller.STATUS_FAILURE_ABORTED -> {
+                clearConfirmation(context)
+                UpdateInstaller.reset()
+            }
+
+            else -> {
+                clearConfirmation(context)
+                UpdateInstaller.onInstallFailed(context)
+            }
+        }
+    }
+
+    private fun requestConfirmation(
+        context: Context,
+        intent: Intent,
+    ) {
+        val confirmation = intent.confirmationIntent() ?: return UpdateInstaller.onInstallFailed(context)
+        confirmation.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        UpdateInstaller.onAwaitingConfirmation()
+
+        // A receiver cannot launch an activity while the app sits in the background,
+        // so the prompt is offered as a notification instead of being dropped.
+        if (isAppInForeground(context)) {
+            context.startActivity(confirmation)
+        } else {
+            notifyConfirmationReady(context, confirmation)
+        }
+    }
+
+    private fun isAppInForeground(context: Context): Boolean {
+        val manager = context.getSystemService(ActivityManager::class.java) ?: return false
+        val ownPid = Process.myPid()
+        return manager.runningAppProcesses?.any {
+            it.pid == ownPid && it.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        } == true
+    }
+
+    private fun notifyConfirmationReady(
+        context: Context,
+        confirmation: Intent,
+    ) {
+        val pending =
+            PendingIntent.getActivity(
+                context,
+                CONFIRM_REQUEST_CODE,
+                confirmation,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+
+        val notification =
+            NotificationCompat
+                .Builder(context, UPDATES_CHANNEL_ID)
+                .setSmallIcon(R.drawable.update)
+                .setContentTitle(context.getString(R.string.update_ready_to_install))
+                .setContentText(context.getString(R.string.tap_to_install_update))
+                .setContentIntent(pending)
+                .setAutoCancel(true)
+                .build()
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            NotificationManagerCompat.from(context).notify(CONFIRM_NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun Intent.confirmationIntent(): Intent? =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            getParcelableExtra(Intent.EXTRA_INTENT)
+        }
+}

--- a/app/src/main/kotlin/com/metrolist/music/utils/UpdateInstaller.kt
+++ b/app/src/main/kotlin/com/metrolist/music/utils/UpdateInstaller.kt
@@ -1,0 +1,251 @@
+/**
+ * Metrolist Project (C) 2026
+ * Licensed under GPL-3.0 | See git history for contributors
+ */
+
+package com.metrolist.music.utils
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.provider.Settings
+import androidx.core.net.toUri
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.contentLength
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+
+enum class UpdateInstallFailure {
+    PermissionRequired,
+    Download,
+    Install,
+}
+
+sealed interface UpdateInstallState {
+    data object Idle : UpdateInstallState
+
+    data class Downloading(
+        val progress: Float,
+    ) : UpdateInstallState
+
+    data object Installing : UpdateInstallState
+
+    data object AwaitingConfirmation : UpdateInstallState
+
+    data class Failed(
+        val reason: UpdateInstallFailure,
+    ) : UpdateInstallState
+}
+
+/**
+ * Downloads a release APK from GitHub and hands it to the system package installer.
+ */
+object UpdateInstaller {
+    private const val UPDATE_DIR_NAME = "updates"
+    private const val UPDATE_FILE_NAME = "update.apk"
+    private const val SESSION_ENTRY_NAME = "update"
+    private const val DOWNLOAD_TIMEOUT_MILLIS = 30 * 60 * 1000L
+
+    // The engine default request timeout is far too short for an APK sized download
+    private val client =
+        HttpClient(CIO) {
+            engine { requestTimeout = DOWNLOAD_TIMEOUT_MILLIS }
+        }
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var activeJob: Job? = null
+
+    private val mutableState = MutableStateFlow<UpdateInstallState>(UpdateInstallState.Idle)
+    val state: StateFlow<UpdateInstallState> = mutableState.asStateFlow()
+
+    fun canInstallPackages(context: Context): Boolean = context.packageManager.canRequestPackageInstalls()
+
+    fun unknownSourcesSettingsIntent(context: Context): Intent =
+        Intent(
+            Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+            "package:${context.packageName}".toUri(),
+        )
+
+    fun reset() {
+        mutableState.value = UpdateInstallState.Idle
+    }
+
+    /**
+     * Starts the download on an app scoped coroutine so it survives screen changes.
+     */
+    fun start(
+        context: Context,
+        downloadUrl: String,
+    ) {
+        if (activeJob?.isActive == true) return
+
+        val appContext = context.applicationContext
+        activeJob = scope.launch { downloadAndInstall(appContext, downloadUrl) }
+    }
+
+    private suspend fun downloadAndInstall(
+        context: Context,
+        downloadUrl: String,
+    ) {
+        UpdateInstallReceiver.clearConfirmation(context)
+
+        if (!canInstallPackages(context)) {
+            mutableState.value = UpdateInstallState.Failed(UpdateInstallFailure.PermissionRequired)
+            return
+        }
+
+        val apk =
+            download(context, downloadUrl).getOrElse {
+                reportFailure(context, UpdateInstallFailure.Download)
+                return
+            }
+
+        mutableState.value = UpdateInstallState.Installing
+        runCatching { commitInstallSession(context, apk) }
+            .onFailure { reportFailure(context, UpdateInstallFailure.Install) }
+    }
+
+    private suspend fun download(
+        context: Context,
+        downloadUrl: String,
+    ): Result<File> =
+        runCatching {
+            val target = prepareTargetFile(context)
+            mutableState.value = UpdateInstallState.Downloading(0f)
+
+            client.prepareGet(downloadUrl).execute { response ->
+                val totalBytes = response.contentLength() ?: 0L
+                response.bodyAsChannel().toInputStream().use { input ->
+                    target.outputStream().use { output ->
+                        copyReportingProgress(input, output, totalBytes) { progress ->
+                            mutableState.value = UpdateInstallState.Downloading(progress)
+                        }
+                    }
+                }
+            }
+
+            target
+        }
+
+    private fun commitInstallSession(
+        context: Context,
+        apk: File,
+    ) {
+        val packageInstaller = context.packageManager.packageInstaller
+        val params =
+            PackageInstaller
+                .SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+                .apply { setAppPackageName(context.packageName) }
+        val sessionId = packageInstaller.createSession(params)
+
+        try {
+            packageInstaller.openSession(sessionId).use { session ->
+                session.openWrite(SESSION_ENTRY_NAME, 0, apk.length()).use { sessionStream ->
+                    apk.inputStream().use { it.copyTo(sessionStream) }
+                    session.fsync(sessionStream)
+                }
+                session.commit(statusIntentSender(context, sessionId))
+            }
+        } catch (throwable: Throwable) {
+            packageInstaller.abandonSession(sessionId)
+            throw throwable
+        }
+    }
+
+    private fun statusIntentSender(
+        context: Context,
+        sessionId: Int,
+    ): IntentSender {
+        val intent =
+            Intent(context, UpdateInstallReceiver::class.java)
+                .setAction(UpdateInstallReceiver.ACTION_INSTALL_STATUS)
+
+        var flags = PendingIntent.FLAG_UPDATE_CURRENT
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags = flags or PendingIntent.FLAG_MUTABLE
+        }
+
+        return PendingIntent.getBroadcast(context, sessionId, intent, flags).intentSender
+    }
+
+    internal fun onAwaitingConfirmation() {
+        mutableState.value = UpdateInstallState.AwaitingConfirmation
+    }
+
+    internal fun onInstallFailed(context: Context) {
+        reportFailure(context, UpdateInstallFailure.Install)
+    }
+
+    internal fun onInstallSucceeded(context: Context) {
+        discardDownloadedApk(context)
+        mutableState.value = UpdateInstallState.Idle
+    }
+
+    private fun reportFailure(
+        context: Context,
+        reason: UpdateInstallFailure,
+    ) {
+        discardDownloadedApk(context)
+        mutableState.value = UpdateInstallState.Failed(reason)
+    }
+
+    private fun updateApkFile(context: Context): File = File(File(context.cacheDir, UPDATE_DIR_NAME), UPDATE_FILE_NAME)
+
+    private fun prepareTargetFile(context: Context): File {
+        File(context.cacheDir, UPDATE_DIR_NAME).mkdirs()
+        return updateApkFile(context).apply { delete() }
+    }
+
+    private fun discardDownloadedApk(context: Context) {
+        updateApkFile(context).delete()
+    }
+}
+
+private const val COPY_BUFFER_SIZE = 64 * 1024
+
+/**
+ * Copies the stream and reports progress once per whole percent, or never when the size is unknown.
+ */
+internal fun copyReportingProgress(
+    input: InputStream,
+    output: OutputStream,
+    totalBytes: Long,
+    onProgress: (Float) -> Unit,
+) {
+    val buffer = ByteArray(COPY_BUFFER_SIZE)
+    var copiedBytes = 0L
+    var reportedPercent = -1
+
+    while (true) {
+        val readBytes = input.read(buffer)
+        if (readBytes < 0) break
+
+        output.write(buffer, 0, readBytes)
+        copiedBytes += readBytes
+
+        if (totalBytes <= 0L) continue
+
+        val percent = (copiedBytes * 100 / totalBytes).toInt()
+        if (percent != reportedPercent) {
+            reportedPercent = percent
+            onProgress(percent / 100f)
+        }
+    }
+
+    output.flush()
+}

--- a/app/src/main/res/values/metrolist_strings.xml
+++ b/app/src/main/res/values/metrolist_strings.xml
@@ -254,6 +254,15 @@
     <string name="hide_changelog">Hide changelog</string>
     <string name="view_changelog">View changelog</string>
     <string name="failed_to_check_updates">Failed to check for updates: %s</string>
+    <string name="download_and_install">Download and install</string>
+    <string name="downloading_update">Downloading update… %d%%</string>
+    <string name="installing_update">Installing update…</string>
+    <string name="update_download_failed">Download failed. Check your connection and try again.</string>
+    <string name="update_install_failed">Install failed. You can download the APK from GitHub instead.</string>
+    <string name="update_install_permission_required">Meld needs permission to install apps before it can update itself.</string>
+    <string name="update_ready_to_install">Update ready to install</string>
+    <string name="tap_to_install_update">Tap to finish installing the update</string>
+    <string name="awaiting_install_confirmation">Waiting for install confirmation. Check your notifications if the prompt did not appear.</string>
 
     <string name="all_time">All time</string>
     <string name="past_24_hours">Past 24 hours</string>

--- a/app/src/test/kotlin/com/metrolist/music/utils/UpdateInstallerTest.kt
+++ b/app/src/test/kotlin/com/metrolist/music/utils/UpdateInstallerTest.kt
@@ -1,0 +1,60 @@
+package com.metrolist.music.utils
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+class UpdateInstallerTest {
+    private fun payload(size: Int) = ByteArray(size) { (it % 256).toByte() }
+
+    @Test
+    fun `copyReportingProgress writes every byte of the source`() {
+        val source = payload(300_000)
+        val output = ByteArrayOutputStream()
+
+        copyReportingProgress(ByteArrayInputStream(source), output, source.size.toLong()) { }
+
+        assertArrayEquals(source, output.toByteArray())
+    }
+
+    @Test
+    fun `copyReportingProgress ends at full progress`() {
+        val source = payload(300_000)
+        val reported = mutableListOf<Float>()
+
+        copyReportingProgress(ByteArrayInputStream(source), ByteArrayOutputStream(), source.size.toLong()) {
+            reported += it
+        }
+
+        assertEquals(1f, reported.last(), 0f)
+    }
+
+    @Test
+    fun `copyReportingProgress reports monotonically without repeating a percent`() {
+        val source = payload(5_000_000)
+        val reported = mutableListOf<Float>()
+
+        copyReportingProgress(ByteArrayInputStream(source), ByteArrayOutputStream(), source.size.toLong()) {
+            reported += it
+        }
+
+        assertEquals(reported.distinct(), reported)
+        assertEquals(reported.sorted(), reported)
+        assertTrue(reported.size <= 101)
+    }
+
+    @Test
+    fun `copyReportingProgress reports nothing when the size is unknown`() {
+        val source = payload(300_000)
+        val output = ByteArrayOutputStream()
+        val reported = mutableListOf<Float>()
+
+        copyReportingProgress(ByteArrayInputStream(source), output, 0L) { reported += it }
+
+        assertTrue(reported.isEmpty())
+        assertArrayEquals(source, output.toByteArray())
+    }
+}


### PR DESCRIPTION
## Problem

The updater can tell you a new release exists, but it cannot install it.

Every entry point handed the user off to a browser. Tapping the update notification, the "New version available" row in the account sheet, and the same row in the settings list all fired `Intent.ACTION_VIEW` on the asset URL, leaving the user to download the APK, find it in a file manager and sideload it by hand. The updater screen itself had no download action at all, only a changelog view.

This is the flow described on #160 as "the in-app updater fetches the latest APK from GitHub Releases and hands it to the system package installer". That is not what the code did: nothing in the app downloaded an APK or talked to `PackageInstaller`, and `REQUEST_INSTALL_PACKAGES` was never declared, so an in-app install was not possible.

## Cause

`MainActivity`, `AccountSettings` and `SettingsScreen` were the only consumers of `Updater.getDownloadUrlForCurrentVariant()`, and all three treated it as a plain URL to open externally. The download and install half of the updater was never written.

## Solution

- Add `UpdateInstaller`, which streams the release APK for the running variant into the app cache and commits it through a `PackageInstaller` session. Progress is reported once per whole percent and exposed as a `StateFlow`.
- Add `UpdateInstallReceiver` for install session status, including launching the system confirmation prompt on `STATUS_PENDING_USER_ACTION`. A user cancel (`STATUS_FAILURE_ABORTED`) resets quietly rather than surfacing an error.
- Run the download on an app scoped coroutine so leaving the screen does not cancel it.
- Declare `REQUEST_INSTALL_PACKAGES`. When the user has not allowed installs from Meld, the updater screen explains why and links to the system setting instead of failing silently.
- Give the updater screen a "Download and install" action with a progress bar, seeded from the cached check result so arriving from the notification shows the action immediately.
- Point the notification, the account sheet row and the settings list row at the updater screen instead of a browser.

`PackageInstaller` was chosen over the older `ACTION_VIEW` plus `FileProvider` install because it reports the session result back, which is what makes the cancel and failure handling above possible. It also needs no `FileProvider` entry.

Everything stays behind `BuildConfig.UPDATER_AVAILABLE`, so the `izzy` variant is unaffected and continues to let the store handle updates.

## Testing

Automated, matching PR CI:

```
./gradlew :app:testFossDebugUnitTest :spotify:test :betterlyrics:test
./gradlew assembleFossDebug :app:lintFossDebug
```

Both pass. Lint reports no issues in any added or modified file.

`UpdateInstallerTest` covers the progress reporting: byte for byte copy of the source, terminal progress of 1.0, no repeated or out of order percent, and no reporting when the response has no content length.

Manual, on an Android 17 arm64 emulator. A self update requires the installed APK and the downloaded APK to share an `applicationId` and a signing key, so testing against the real signed release is not possible from a local build. Instead the release endpoint was pointed at a local mock serving a locally built APK signed with the same key, which exercises the real download and install path:

- Update detected, notification posted, tapping it opens the updater screen already populated
- Download progress shown, system dialog reads "Update this app?", app self updated from 0.8.8 to 0.8.9 and relaunched
- Same flow verified from the account sheet row and the settings list row, both staying in app
- With "install unknown apps" revoked, the permission message and link to system settings appear, and the flow works after granting
- Cancelling at the system dialog leaves no error and the action stays available

This surfaced one real bug that is fixed here: the ktor CIO engine defaults to a 15 second request timeout, which aborted the APK download every time. The download client now sets an explicit timeout.

One behaviour worth noting for reviewers: on devices with Play Services, Play Protect may add its own "App scan recommended" prompt before the install completes. That applies to any sideload updater and is outside the app's control.

## Related Issues

- Related to #160

## Video Screencast

https://github.com/user-attachments/assets/75599e11-d8a8-4a20-aa20-0c7c465f0f52

